### PR TITLE
Use HTTP_X_FORWARDED_HOST if available

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -69,14 +69,14 @@ function get_absolute_root_url($with_scheme=true)
     else
     {
       $url .= $_SERVER['HTTP_HOST'];
-    }
-    if ( (!$is_https && $_SERVER['SERVER_PORT'] != 80)
-          ||($is_https && $_SERVER['SERVER_PORT'] != 443))
-    {
-      $url_port = ':'.$_SERVER['SERVER_PORT'];
-      if (strrchr($url, ':') != $url_port)
+      if ( (!$is_https && $_SERVER['SERVER_PORT'] != 80)
+            ||($is_https && $_SERVER['SERVER_PORT'] != 443))
       {
-        $url .= $url_port;
+        $url_port = ':'.$_SERVER['SERVER_PORT'];
+        if (strrchr($url, ':') != $url_port)
+        {
+          $url .= $url_port;
+        }
       }
     }
   }

--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -62,7 +62,14 @@ function get_absolute_root_url($with_scheme=true)
     {
       $url .= 'http://';
     }
-    $url .= $_SERVER['HTTP_HOST'];
+    if (isset($_SERVER['HTTP_X_FORWARDED_HOST']))
+    {
+      $url .= $_SERVER['HTTP_X_FORWARDED_HOST'];
+    }
+    else
+    {
+      $url .= $_SERVER['HTTP_HOST'];
+    }
     if ( (!$is_https && $_SERVER['SERVER_PORT'] != 80)
           ||($is_https && $_SERVER['SERVER_PORT'] != 443))
     {


### PR DESCRIPTION
This enables piwigo to be run e.g. in a docker container behind a proxy.
If HTTP_X_FORWARDED_HOST is not set, HTTP_HOST is used as usual