### PR TITLE
fix #367 - Workaround "id-tag" generated for numeric tags

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -520,6 +520,11 @@ function parse_section_url( $tokens, &$next_token)
       {
         $requested_tag_ids[] = $matches[1];
       }
+      elseif ( $conf['tag_url_style'] == 'tag' and preg_match('/^(\d+)-(\d+)$/', $tokens[$i], $matches) )
+      {
+        // Workaround "id-tag" generated for numeric tags.
+        $requested_tag_url_names[] = $matches[2];
+      }
       else
       {
         $requested_tag_url_names[] = $tokens[$i];

--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -520,11 +520,6 @@ function parse_section_url( $tokens, &$next_token)
       {
         $requested_tag_ids[] = $matches[1];
       }
-      elseif ( $conf['tag_url_style'] == 'tag' and preg_match('/^(\d+)-(\d+)$/', $tokens[$i], $matches) )
-      {
-        // Workaround "id-tag" generated for numeric tags.
-        $requested_tag_url_names[] = $matches[2];
-      }
       else
       {
         $requested_tag_url_names[] = $tokens[$i];

--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -379,7 +379,7 @@ function make_section_in_url($params)
             $section_string.= '/'.$tag['id'];
             break;
           case 'tag':
-            if (isset($tag['url_name']) and !is_numeric($tag['url_name']) )
+            if (isset($tag['url_name']))
             {
               $section_string.= '/'.$tag['url_name'];
               break;

--- a/search.php
+++ b/search.php
@@ -119,7 +119,7 @@ if (isset($_POST['submit']))
   {
     $search['fields'][$type_date.'-after'] = array(
       'date' => sprintf(
-        '%d-%02d-%02d',
+        '%d-%02d-%02d 00:00:00',
         $_POST['start_year'],
         $_POST['start_month'] != 0 ? $_POST['start_month'] : '01',
         $_POST['start_day']   != 0 ? $_POST['start_day']   : '01'
@@ -132,7 +132,7 @@ if (isset($_POST['submit']))
   {
     $search['fields'][$type_date.'-before'] = array(
       'date' => sprintf(
-        '%d-%02d-%02d',
+        '%d-%02d-%02d 23:59:59',
         $_POST['end_year'],
         $_POST['end_month'] != 0 ? $_POST['end_month'] : '12',
         $_POST['end_day']   != 0 ? $_POST['end_day']   : '31'


### PR DESCRIPTION
This still would fail if a real tag "42-42" existed. It might be better
to not specialize to id-tag in make_section_in_url() at all, but I
didn't dive into the implications that may have.