### PR TITLE
fix #367 - do not specialize numeric tag to 'id-tag' URL

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -379,7 +379,7 @@ function make_section_in_url($params)
             $section_string.= '/'.$tag['id'];
             break;
           case 'tag':
-            if (isset($tag['url_name']) and !is_numeric($tag['url_name']) )
+            if (isset($tag['url_name']))
             {
               $section_string.= '/'.$tag['url_name'];
               break;


### PR DESCRIPTION
Apparently there is no reason in make_section_in_url() to "escape" a
numeric URL for a tags section if tag_url_style is 'tag'. In
parse_section_url() tag_url_style is checked, and if 'tag' the URL token
is used.