### PR TITLE
Fix layout for IE mobile 11+/Windows Phone 8.1+

### DIFF
--- a/themes/smartpocket/theme.css
+++ b/themes/smartpocket/theme.css
@@ -1,6 +1,8 @@
 @import "jquery.mobile.css";
 @import "photoswipe.css";
 
+@-ms-viewport { width: device-width; }
+
 .title { margin: 10px; text-align: center; }
 .title .ui-btn { margin-top: -5px; }
 . { float: right; }


### PR DESCRIPTION
IE mobile on Windows Phone reports itself with a way too large viewport size. This change hints IE to use the proper device width. Works with Windows Phone 8.1 upwards (IE11+) Windows Phone 8 would require an additional step

For before/after screenshots and discussion see http://piwigo.org/forum/viewtopic.php?id=26612

Reference: http://getbootstrap.com/getting-started/#support-ie10-width