### PR TITLE
Honor X-Forwarded-Proto HTTP Header when set by a frontal reverse-proxy

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -52,8 +52,10 @@ function get_absolute_root_url($with_scheme=true)
   if ($with_scheme)
   {
     $is_https = false;
-    if (isset($_SERVER['HTTPS']) &&
+    if ((isset($_SERVER['HTTPS']) &&
       ((strtolower($_SERVER['HTTPS']) == 'on') or ($_SERVER['HTTPS'] == 1)))
+    || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+      strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false))
     {
       $is_https = true;
       $url .= 'https://';


### PR DESCRIPTION
This fixes a bug in batch resize feature when you try to run it from behind a reverse-proxy that handles SSL encryption, while the server that runs Piwigo serves unencrypted content :
client -> https://reverse-proxy -> http://piwigo_server

In this case, $_SERVER['HTTPS'] is not set on piwigo_server, so get_absolute_root_url would give http://reverse-proxy (instead of https://reverse-proxy)

But if you set the X-Forwarded-Proto header (see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_fields) in the reverse-proxy, this patch handles this case properly.
This can be done on apache with this directive :
RequestHeader set X-Forwarded-Proto "https"

This patch is inspired by this ticket from Wordpress : https://core.trac.wordpress.org/ticket/15733
Please be aware that the patch has not been merged on Wordpress : they preferred to invite users to add some PHP code in their config to handle this manually (see http://codex.wordpress.org/Administration_Over_SSL) :
if (strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false)
       $_SERVER['HTTPS']='on';

The same method can be applied on Piwigo (by adding the same lines of code in local/config/config.inc.php, through the LocalFiles Editor plugin). But I would find it much better to include that in the code of Piwigo, as HTTP_X_FORWARDED_HOST is already handled.
