### PR TITLE
Initial mysqli TLS/SSL support?

### DIFF
--- a/admin/include/functions_upgrade.php
+++ b/admin/include/functions_upgrade.php
@@ -311,7 +311,10 @@ function upgrade_db_connect()
   try
   {
     pwg_db_connect($conf['db_host'], $conf['db_user'],
-                   $conf['db_password'], $conf['db_base']);
+                   $conf['db_password'], $conf['db_base'],
+                   $conf['db_sslkey'], $conf['db_sslcert'],
+                   $conf['db_sslca'], $conf['db_sslcapath'],
+                   $conf['db_sslcipher']);
     pwg_db_check_version();
   }
   catch (Exception $e)

--- a/i.php
+++ b/i.php
@@ -393,7 +393,10 @@ include_once( PHPWG_ROOT_PATH .'/include/derivative_std_params.inc.php');
 try
 {
   pwg_db_connect($conf['db_host'], $conf['db_user'],
-                 $conf['db_password'], $conf['db_base']);
+                 $conf['db_password'], $conf['db_base'],
+                 $conf['db_sslkey'], $conf['db_sslcert'],
+                 $conf['db_sslca'], $conf['db_sslcapath'],
+                 $conf['db_sslcipher']);
 }
 catch (Exception $e)
 {

--- a/include/common.inc.php
+++ b/include/common.inc.php
@@ -115,7 +115,10 @@ $persistent_cache = new PersistentFileCache();
 try
 {
   pwg_db_connect($conf['db_host'], $conf['db_user'],
-                 $conf['db_password'], $conf['db_base']);
+                 $conf['db_password'], $conf['db_base'],
+                 $conf['db_sslkey'], $conf['db_sslcert'],
+                 $conf['db_sslca'], $conf['db_sslcapath'],
+                 $conf['db_sslcipher']);
 }
 catch (Exception $e)
 {

--- a/include/dblayer/functions_mysqli.inc.php
+++ b/include/dblayer/functions_mysqli.inc.php
@@ -42,10 +42,15 @@ define('DB_RANDOM_FUNCTION', 'RAND');
  * @param string $user
  * @param string $password
  * @param string $database
+ * @param string $sslkey
+ * @param string $sslcert
+ * @param string $sslca
+ * @param string $sslcapath
+ * @param string $sslcipher
  *
  * @throws Exception
  */
-function pwg_db_connect($host, $user, $password, $database)
+function pwg_db_connect($host, $user, $password, $database, $sslkey, $sslcert, $sslca, $sslcapath, $sslcipher)
 {
   global $mysqli;
 
@@ -64,8 +69,13 @@ function pwg_db_connect($host, $user, $password, $database)
 
   $dbname = null;
   
-  $mysqli = new mysqli($host, $user, $password, $dbname, $port, $socket);
-  if (mysqli_connect_error())
+  $mysqli = mysqli_init();
+  if (!$mysqli)
+  {
+    throw new Exception("Can't initialize connection to server");
+  }
+  mysqli_ssl_set($mysqli, $sslkey, $sslcert, $sslca, $sslcapath, $sslcipher);
+  if (!$mysqli->real_connect($host, $user, $password, $dbname, $port, $socket))
   {
     throw new Exception("Can't connect to server");
   }

--- a/install.php
+++ b/install.php
@@ -293,6 +293,11 @@ $conf[\'db_base\'] = \''.$dbname.'\';
 $conf[\'db_user\'] = \''.$dbuser.'\';
 $conf[\'db_password\'] = \''.$dbpasswd.'\';
 $conf[\'db_host\'] = \''.$dbhost.'\';
+$conf[\'db_sslkey\'] = NULL;
+$conf[\'db_sslcert\'] = NULL;
+$conf[\'db_sslca\'] = NULL;
+$conf[\'db_sslcapath\'] = NULL;
+$conf[\'db_sslcipher\'] = NULL;
 
 $prefixeTable = \''.$prefixeTable.'\';
 

--- a/upgrade_feed.php
+++ b/upgrade_feed.php
@@ -61,7 +61,10 @@ define('UPGRADES_PATH', PHPWG_ROOT_PATH.'install/db');
 try
 {
   pwg_db_connect($conf['db_host'], $conf['db_user'],
-                 $conf['db_password'], $conf['db_base']);
+                 $conf['db_password'], $conf['db_base'],
+                 $conf['db_sslkey'], $conf['db_sslcert'],
+                 $conf['db_sslca'], $conf['db_sslcapath'],
+                 $conf['db_sslcipher']);
 }
 catch (Exception $e)
 {


### PR DESCRIPTION
Hi,

I've patched my Piwigo installation to support TLS/SSL db connectivity via mysqli, so I'm sending a patch for it.
TLS/SSL parameters are not exposed via installation webpage with this patch, they can be only edited after installation in file local/config/database.inc.php. Installer is patched to insert NULL values by default into local/config/database.inc.php, but upgrade path somehow also needs a way to insert these into the file if they are missing. Or should these be set in include/config_default.php and local/config/database.inc.php will be just override?

I know this is not ready to merge, but please guide me on resolving the missing pieces. My skills with HTML and PHP are minimal.

Thank you in advance.
Martin