### PR TITLE
mysqli: escape raw string values

### DIFF
--- a/include/dblayer/functions_mysqli.inc.php
+++ b/include/dblayer/functions_mysqli.inc.php
@@ -311,7 +311,7 @@ UPDATE '.$tablename.'
 
         if (isset($data[$key]) and $data[$key] != '')
         {
-          $query.= $separator.$key.' = \''.$data[$key].'\'';
+          $query.= $separator.$key.' = \''.pwg_db_real_escape_string($data[$key]).'\'';
         }
         else
         {
@@ -338,7 +338,7 @@ UPDATE '.$tablename.'
           }
           if (isset($data[$key]))
           {
-            $query.= $key.' = \''.$data[$key].'\'';
+            $query.= $key.' = \''.pwg_db_real_escape_string($data[$key]).'\'';
           }
           else
           {
@@ -453,7 +453,7 @@ UPDATE '.$tablename.'
 
     if (isset($value) and $value !== '')
     {
-      $query.= $separator.$key.' = \''.$value.'\'';
+      $query.= $separator.$key.' = \''.pwg_db_real_escape_string($value).'\'';
     }
     else
     {
@@ -481,7 +481,7 @@ UPDATE '.$tablename.'
       }
       if (isset($value))
       {
-        $query.= $key.' = \''.$value.'\'';
+        $query.= $key.' = \''.pwg_db_real_escape_string($value).'\'';
       }
       else
       {
@@ -556,7 +556,7 @@ INSERT '.$ignore.' INTO '.$table_name.'
         }
         else
         {
-          $query .= "'".$insert[$dbfield]."'";
+          $query .= "'".pwg_db_real_escape_string($insert[$dbfield])."'";
         }
       }
       $query .= ')';
@@ -600,7 +600,7 @@ INSERT INTO '.$table_name.'
       }
       else
       {
-        $query .= "'".$value."'";
+        $query .= "'".pwg_db_real_escape_string($value)."'";
       }
     }
     $query .= ')';


### PR DESCRIPTION
I've implemented use of `pwg_db_real_escape_string` in cases where raw strings were injected into SQL code. This will prevent SQL injection and SQL syntax errors when having quotes in filenames (if allowed by the allowed filenames regex).

I've tested it functionally and it works, but I couldn't test it in the system, e.g. I don't know if some input values are subjected to `addslashes` before being used in SQL. It certainly works for sync (mass_inserts). Anyway I believe that any `addslashes` use should be removed when dealing with the database and we should always use the dbms escape tools.

Ref: #250, #544

Signed-off-by: Daniele Ricci <daniele.athome@gmail.com>