### PR TITLE
fix PHPMailer smtp class loading when using SMTP transport

### DIFF
--- a/include/functions_mail.inc.php
+++ b/include/functions_mail.inc.php
@@ -607,7 +607,7 @@ function pwg_mail($to, $args=array(), $tpl=array())
     $conf_mail = get_mail_configuration();
   }
 
-  include_once(PHPWG_ROOT_PATH.'include/phpmailer/class.phpmailer.php');
+  include_once(PHPWG_ROOT_PATH.'include/phpmailer/PHPMailerAutoload.php');
 
   $mail = new PHPMailer;
 


### PR DESCRIPTION
The recent PHPMailer update broke direct SMTP transport (that is when at least $conf['smtp_host'] is set in local/config/config.inc.php)

Fix from https://github.com/PHPMailer/PHPMailer/issues/113