### PR TITLE
Include the current user's id in the session info

### DIFF
--- a/include/ws_functions/pwg.php
+++ b/include/ws_functions/pwg.php
@@ -317,6 +317,7 @@ function ws_session_getStatus($params, &$service)
   global $user, $conf;
 
   $res['username'] = is_a_guest() ? 'guest' : stripslashes($user['username']);
+  $res['user_id'] = is_a_guest() ? 'guest' : $user['id'];
   foreach ( array('status', 'theme', 'language') as $k )
   {
     $res[$k] = $user[$k];


### PR DESCRIPTION
I couldn't find a straightforward way of getting the current user's id, so this seemed like the most reasonable place to propose the change. This would be useful when using the api to call other methods that might require a user id (such as the user collections extension)