### PR TITLE
Fix for action.php and corrupted image download

### DIFF
--- a/action.php
+++ b/action.php
@@ -235,7 +235,9 @@ if (ini_get('safe_mode') == 0)
 {
   @set_time_limit(0);
 }
-
+// Without clean and flush there may be some image download problems, or image can be corrupted after download
+ob_clean();
+flush();
 @readfile($file);
 
 ?>


### PR DESCRIPTION
My users where complaining, that downloaded images with download button, are corrupted (right click on image was fine). I've check all plugins and it came out, there is a problem in gallery core file. Pictures where downloaded, but file content was a complete garbage (it had noting to do with a file, except right size). After investigation, it looks like we need to "ob_clean — Clean (erase) the output buffer" and "flush — Flush system output buffer" before doing readfile(). This could be perhaps only something characteristic for my configuration (apache2.4.25, php5.6.26,Linux) but as far as I can see, those two commands are consider "recommended" for "readfile" (http://php.net/manual/en/function.readfile.php#81925) streaming, they fixed my problem, and they should not be  harmful for others.