### PR TITLE
Fixes #767 - Return a 500 HTTP status when a file upload error occurs.

### DIFF
--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -740,7 +740,7 @@ UPDATE '. IMAGES_TABLE .'
  *    @option int rank
  */
 function ws_images_setRank($params, $service)
-{  
+{
   if (count($params['image_id']) > 1)
   {
     include_once(PHPWG_ROOT_PATH.'admin/include/functions.php');
@@ -773,7 +773,7 @@ SELECT
   {
     return new PwgError(WS_ERR_MISSING_PARAM, 'rank is missing');
   }
-  
+
   // does the image really exist?
   $query = '
 SELECT COUNT(*)
@@ -1167,11 +1167,46 @@ SELECT id, name, permalink
  */
 function ws_images_addSimple($params, $service)
 {
-  global $conf;
+  global $conf, $logger;
 
   if (!isset($_FILES['image']))
   {
     return new PwgError(405, 'The image (file) is missing');
+  }
+
+  if (isset($_FILES['image']['error']) && $_FILES['image']['error'] != 0)
+  {
+    switch($_FILES['image']['error'])
+    {
+      case UPLOAD_ERR_INI_SIZE:
+        $message = 'The uploaded file exceeds the upload_max_filesize directive in php.ini.';
+        break;
+      case UPLOAD_ERR_FORM_SIZE:
+        $message = 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form.';
+        break;
+      case UPLOAD_ERR_PARTIAL:
+        $message = 'The uploaded file was only partially uploaded.';
+        break;
+      case UPLOAD_ERR_NO_FILE:
+        $message = 'No file was uploaded.';
+        break;
+      case UPLOAD_ERR_NO_TMP_DIR:
+        $message = 'Missing a temporary folder.';
+        break;
+      case UPLOAD_ERR_CANT_WRITE:
+        $message = 'Failed to write file to disk.';
+        break;
+      case UPLOAD_ERR_EXTENSION:
+        $message = 'A PHP extension stopped the file upload. ' .
+        'PHP does not provide a way to ascertain which extension caused the file ' .
+        'upload to stop; examining the list of loaded extensions with phpinfo() may help.',
+        break;
+      default:
+        $message = "Error number {$_FILES['image']['error']} occurred while uploading a file."
+    }
+
+    $logger->error(__FUNCTION__ . " " . $message);
+    return new PwgError(500, $message);
   }
 
   if ($params['image_id'] > 0)

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -1202,7 +1202,7 @@ function ws_images_addSimple($params, $service)
         'upload to stop; examining the list of loaded extensions with phpinfo() may help.';
         break;
       default:
-        $message = "Error number {$_FILES['image']['error']} occurred while uploading a file."
+        $message = "Error number {$_FILES['image']['error']} occurred while uploading a file.";
     }
 
     $logger->error(__FUNCTION__ . " " . $message);

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -1199,7 +1199,7 @@ function ws_images_addSimple($params, $service)
       case UPLOAD_ERR_EXTENSION:
         $message = 'A PHP extension stopped the file upload. ' .
         'PHP does not provide a way to ascertain which extension caused the file ' .
-        'upload to stop; examining the list of loaded extensions with phpinfo() may help.',
+        'upload to stop; examining the list of loaded extensions with phpinfo() may help.';
         break;
       default:
         $message = "Error number {$_FILES['image']['error']} occurred while uploading a file."


### PR DESCRIPTION
This PR introduces explicit error handling for common documented file upload errors to aid in troubleshooting.