### PR TITLE
Add missing i18n message

### DIFF
--- a/language/en_UK/admin.lang.php
+++ b/language/en_UK/admin.lang.php
@@ -995,6 +995,7 @@ $lang['delete album and all %d photos, even the %d associated to other albums'] 
 $lang['delete album and the %d orphan photos'] = 'delete album and the %d orphan photos';
 $lang['delete only album, not photos'] = 'delete only album, not photos';
 $lang['Confirm deletion'] = 'Confirm deletion';
+$lang['Deletion in progress'] = 'Deletion in progress';
 $lang['checksum'] = 'checksum';
 $lang['orphans to delete'] = 'orphans to delete';
 $lang['Dashboard'] = 'Dashboard';


### PR DESCRIPTION
Hi,

I've gotten this error in JS:

> SyntaxError: unterminated string literal admin.php:616:24

Because of an error with a `l10n()` call:
```
<script type="text/javascript">//<![CDATA[
var lang = {
	Cancel: 'Cancel',
	deleteProgressMessage: "<br />
<font size='1'><table class='xdebug-error xe-warning' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Warning: [l10n] language key "Deletion in progress" not defined in piwigo/include/functions.inc.php on line <i>1096</i></th></tr>

[etc.]
```

The crux of which is:

> Warning: [l10n] language key "Deletion in progress" not defined in piwigo/include/functions.inc.php on line 1096

This patch adds the missing key. I don't think it differs in GB or UK English so it's not added to those files (is this the correct approach?).
