### PR TITLE
Use entire language code.

### DIFF
--- a/include/functions_user.inc.php
+++ b/include/functions_user.inc.php
@@ -814,7 +814,7 @@ function get_browser_language()
   $browser_language = substr(@$_SERVER["HTTP_ACCEPT_LANGUAGE"], 0, 2);
   foreach (get_languages() as $language_code => $language_name)
   {
-    if (substr($language_code, 0, 2) == $browser_language)
+    if (explode("_", $language_code)[0] == $browser_language)
     {
       return $language_code;
     }


### PR DESCRIPTION
HTTP_ACCEPT_LANGUAGE="ko" would match "kok_IN" instead of correctly matching "ko_KR"