### PR TITLE
user list: use HTTP GET method for user_list_backend.php

### DIFF
--- a/admin/themes/default/template/user_list.tpl
+++ b/admin/themes/default/template/user_list.tpl
@@ -614,14 +614,8 @@ jQuery(document).on('click', '.close-user-details',  function(e) {
     deferRender: true,
     processing: true,
     serverSide: true,
-		serverMethod: "POST",
-    ajax: {
-        url : "admin/user_list_backend.php",
-        type : "POST",
-        data : {
-            pwg_token : pwg_token
-        }
-    },
+		serverMethod: "GET",
+    ajaxSource: "admin/user_list_backend.php",
 		pagingType: "simple",
     language: {
       processing: "{/literal}{'Loading...'|translate|escape:'javascript'}{literal}",


### PR DESCRIPTION
Revert to the old Datatables "ajax" API instead of the newer
"ajaxSource" API. This API change was only necessary in order to
supply the pwg_token as POST data, but the user list can be
retrieved without the pwg_token via GET.