### PR TITLE
Call non-static method using object.

### DIFF
--- a/include/template.class.php
+++ b/include/template.class.php
@@ -583,7 +583,7 @@ class Template
         'AAAA_DEBUG_TOTAL_TIME__' => get_elapsed_time($t2, get_moment())
         )
         );
-      Smarty_Internal_Debug::display_debug($this->smarty);
+      $this->smarty->_debug->display_debug($this->smarty);
     }
   }
 


### PR DESCRIPTION
Replace bad static call with a call to the non-static method using the appropriate object.

Closes #912 