### PR TITLE
Quote 'rank' field name in SQL

### DIFF
--- a/admin/cat_list.php
+++ b/admin/cat_list.php
@@ -349,7 +349,7 @@ $template->assign(array(
 $categories = array();
 
 $query = '
-SELECT id, name, permalink, dir, rank, status
+SELECT id, name, permalink, dir, `rank`, status
   FROM '.CATEGORIES_TABLE;
 if (!isset($_GET['parent_id']))
 {
@@ -362,7 +362,7 @@ else
   WHERE id_uppercat = '.$_GET['parent_id'];
 }
 $query.= '
-  ORDER BY rank ASC
+  ORDER BY `rank` ASC
 ;';
 $categories = hash_from_query($query, 'id');
 

--- a/admin/element_set_ranks.php
+++ b/admin/element_set_ranks.php
@@ -158,11 +158,11 @@ SELECT
     representative_ext,
     width, height, rotation,
     name,
-    rank
+    `rank`
   FROM '.IMAGES_TABLE.'
     JOIN '.IMAGE_CATEGORY_TABLE.' ON image_id = id
   WHERE category_id = '.$page['category_id'].'
-  ORDER BY rank
+  ORDER BY `rank`
 ;';
 $result = pwg_query($query);
 if (pwg_db_num_rows($result) > 0)

--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -644,9 +644,9 @@ function get_fs_directories($path, $recursive = true)
 function update_global_rank()
 {
   $query = '
-SELECT id, id_uppercat, uppercats, rank, global_rank
+SELECT id, id_uppercat, uppercats, `rank`, global_rank
   FROM '.CATEGORIES_TABLE.'
-  ORDER BY id_uppercat,rank,name';
+  ORDER BY id_uppercat, `rank`, name';
 
   global $cat_map; // used in preg_replace callback
   $cat_map = array();
@@ -1410,7 +1410,7 @@ function create_virtual_category($category_name, $parent_id=null, $options=array
   {
     //what is the current higher rank for this parent?
     $query = '
-SELECT MAX(rank) AS max_rank
+SELECT MAX(`rank`) AS max_rank
   FROM '. CATEGORIES_TABLE .'
   WHERE id_uppercat '.(empty($parent_id) ? 'IS NULL' : '= '.$parent_id).' 
 ;';
@@ -1883,9 +1883,9 @@ SELECT
   $query = '
 SELECT
     category_id,
-    MAX(rank) AS max_rank
+    MAX(`rank`) AS max_rank
   FROM '.IMAGE_CATEGORY_TABLE.'
-  WHERE rank IS NOT NULL
+  WHERE `rank` IS NOT NULL
     AND category_id IN ('.implode(',', $categories).')
   GROUP BY category_id
 ;';

--- a/admin/site_update.php
+++ b/admin/site_update.php
@@ -193,7 +193,7 @@ SELECT id
 
   // let's see if some categories already have some sub-categories...
   $query = '
-SELECT id_uppercat, MAX(rank)+1 AS next_rank
+SELECT id_uppercat, MAX(`rank`)+1 AS next_rank
   FROM '.CATEGORIES_TABLE.'
   GROUP BY id_uppercat';
   $result = pwg_query($query);


### PR DESCRIPTION
Add backticks to reserved word 'rank' in SQL queries.

Bug: GH #919