### PR TITLE
Improve permalink generation

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -339,7 +339,7 @@ if (function_exists('mb_strtolower') && defined('PWG_CHARSET'))
    */
   function pwg_transliterate($term)
   {
-    return remove_accents( mb_strtolower($term, PWG_CHARSET) );
+    return remove_accents($term, PWG_CHARSET);
   }
 }
 else
@@ -349,7 +349,7 @@ else
    */
   function pwg_transliterate($term)
   {
-    return remove_accents( strtolower($term) );
+    return remove_accents($term);
   }
 }
 
@@ -362,9 +362,11 @@ else
 function str2url($str)
 {
   $str = $safe = pwg_transliterate($str);
-  $str = preg_replace('/[^\x80-\xffa-z0-9_\s\'\:\/\[\],-]/','',$str);
-  $str = preg_replace('/[\s\'\:\/\[\],-]+/',' ',trim($str));
+  $str = preg_replace('/[\.]/','-',$str);
+  $str = preg_replace('/[^\x80-\xffA-Za-z0-9_\s\'\:\/\[\],-]/','',$str);
+  $str = preg_replace('/[\s\'\:\/\[\],]+/',' ',trim($str));
   $res = str_replace(' ','_',$str);
+  $res = preg_replace('/[\-]+/', '-', $res);
 
   if (empty($res))
   {

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -373,6 +373,10 @@ function str2url($str)
     $res = str_replace(' ','_', $safe);
   }
 
+  if (mb_strlen($res) > 64) {
+    $res = mb_substr($res, 0, 64);
+  }
+
   return $res;
 }
 


### PR DESCRIPTION
I found the auto-generated permalinks ugly, so I hacked into the code and made a few improvements:
- allow upper case characters
- replace '.' by '-' (instead of '')
- merge multiple '-' into a single '-'

A second commit chops permalinks at 64 characters. As the database column is limited to 64 characters, this resulted in SQL errors for longer titles.