### PR TITLE
Made format subdirectory (i.e. "pwg_format") configurable

### DIFF
--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -610,7 +610,7 @@ function get_fs_directories($path, $recursive = true)
       '.', '..', '.svn',
       'thumbnail', 'pwg_high',
       'pwg_representative',
-      'pwg_format',
+      $conf['format_dir'],
       )
     );
   $exclude_folders = array_flip($exclude_folders);

--- a/admin/site_reader_local.php
+++ b/admin/site_reader_local.php
@@ -112,7 +112,7 @@ function get_elements($path)
       else if (is_dir($path.'/'.$node)
                and $node != 'pwg_high'
                and $node != 'pwg_representative'
-               and $node != 'pwg_format'
+               and $node != $conf['format_dir']
                and $node != 'thumbnail' )
       {
         $subdirs[] = $node;
@@ -193,7 +193,7 @@ function get_formats($path, $filename_wo_ext)
 
   $formats = array();
   
-  $base_test = $path.'/pwg_format/'.$filename_wo_ext.'.';
+  $base_test = $path.'/'.$conf['format_dir'].'/'.$filename_wo_ext.'.';
   
   foreach ($conf['format_ext'] as $ext)
   {

--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -67,8 +67,13 @@ $conf['file_ext'] = array_merge(
 $conf['enable_formats'] = false;
 
 // format_ext : file extensions for formats, ie additional versions of a
-// photo (or nay other file). Formats are in sub-directory pwg_format.
+// photo (or any other file). Formats are in the sub-directory specified
+// by format_dir below (default: pwg_format).
 $conf['format_ext'] = array('cr2', 'tif', 'tiff', 'nef', 'dng', 'ai', 'psd');
+
+// format_dir : name of the directory in which to search for formats. Use
+// '.' if formats are stored alongside the original version.
+$conf['format_dir'] = 'pwg_format';
 
 // top_number : number of element to display for "best rated" and "most
 // visited" categories

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1007,8 +1007,10 @@ function original_to_representative($path, $representative_ext)
  */
 function original_to_format($path, $format_ext)
 {
+  global $conf;
+
   $pos = strrpos($path, '/');
-  $path = substr_replace($path, 'pwg_format/', $pos+1, 0);
+  $path = substr_replace($path, $conf['format_dir'].'/', $pos+1, 0);
   $pos = strrpos($path, '.');
   return substr_replace($path, $format_ext, $pos+1);
 }


### PR DESCRIPTION
Currently the multiple formats feature looks for formats in a hard-coded sub-directory, `pwg_format`, but it's not always desirable to organise files this way. 

This change makes the name of the subdirectory a config variable (`format_dir`), defaulting to `pwg_format` to maintain backwards compatibility. It can be set to `.` to maintain a flat file structure.