### PR TITLE
Addresses conflicts when using Mysql8 in pwg_log

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -466,11 +466,11 @@ UPDATE '.USER_INFOS_TABLE.'
   $query = '
 INSERT INTO '.HISTORY_TABLE.'
   (
-    date,
-    time,
+    `date`,
+    `time`,
     user_id,
     IP,
-    section,
+    `section`,
     category_id,
     image_id,
     image_type,


### PR DESCRIPTION
In Mysql8 reserved words in sql statements have to go in backticks. Of course this fix is addressing only one of many occurences accross the core, but maybe it can be a start of making Piwigo Mysql8 comptatible.