### PR TITLE
Search engine won't index picture page | Correct logic and makes issue #698 fixable by themes / user

### DIFF
--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -362,6 +362,10 @@ $conf['use_iptc_mapping'] = array(
 // available)
 $conf['show_exif'] = true;
 
+// show_exif_default: Show EXIF metadata by default on picture.php (needs show
+// exif to be set to true)
+$conf['show_exif_default'] = false;
+
 // show_exif_fields : in EXIF fields, you can choose to display fields in
 // sub-arrays, for example ['COMPUTED']['ApertureFNumber']. for this, add
 // 'COMPUTED;ApertureFNumber' in $conf['show_exif_fields']

--- a/picture.php
+++ b/picture.php
@@ -633,7 +633,7 @@ $metadata_showable = trigger_change(
   $picture['current']
   );
 
-if ( $metadata_showable and pwg_get_session_var('show_metadata') )
+if ( $metadata_showable and ( $conf['show_exif_default'] != pwg_get_session_var('show_metadata') ))
 {
   $page['meta_robots']=array('noindex'=>1, 'nofollow'=>1);
 }

--- a/picture.php
+++ b/picture.php
@@ -635,7 +635,7 @@ $metadata_showable = trigger_change(
 
 if ( $metadata_showable and ( $conf['show_exif_default'] != pwg_get_session_var('show_metadata') ))
 {
-  $page['meta_robots']=array('noindex'=>1, 'nofollow'=>1);
+  $page['meta_robots']=array('noindex'=>1);
 }
 
 


### PR DESCRIPTION
To discuss:

Should this be set by themes automatically or should there be an UI toggle (I might not be able to do this) to make this easily changeable by user.

Although this seems like a lot of work, I am for themes fixing this issue. If theme does not fix it, no change in behaviour is expected. So this seems like an good idea given this issue has been over a year in prio highest.