### PR TITLE
issue #919 replace rank column in database

### DIFF
--- a/admin/cat_list.php
+++ b/admin/cat_list.php
@@ -309,7 +309,7 @@ $template->assign(array(
 $categories = array();
 
 $query = '
-SELECT id, name, permalink, dir, rank, status
+SELECT id, name, permalink, dir, cat_rank, status
   FROM '.CATEGORIES_TABLE;
 if (!isset($_GET['parent_id']))
 {
@@ -322,7 +322,7 @@ else
   WHERE id_uppercat = '.$_GET['parent_id'];
 }
 $query.= '
-  ORDER BY rank ASC
+  ORDER BY cat_rank ASC
 ;';
 $categories = hash_from_query($query, 'id');
 
@@ -407,7 +407,7 @@ foreach ($categories as $category)
       'NB_SUB_PHOTOS' => isset($nb_sub_photos[$category['id']]) ? $nb_sub_photos[$category['id']] : 0,
       'NB_SUB_ALBUMS' => isset($subcats_of[$category['id']]) ? count($subcats_of[$category['id']]) : 0,
       'ID'         => $category['id'],
-      'RANK'       => $category['rank']*10,
+      'RANK'       => $category['cat_rank']*10,
 
       'U_JUMPTO'   => make_index_url(
         array(

--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -135,7 +135,7 @@ $sort_fields = array(
   'hit ASC'             => l10n('Visits, low &rarr; high'),
   'id ASC'              => l10n('Numeric identifier, 1 &rarr; 9'),
   'id DESC'             => l10n('Numeric identifier, 9 &rarr; 1'),
-  'rank ASC'            => l10n('Manual sort order'),
+  'ima_rank ASC'            => l10n('Manual sort order'),
   );
 
 $comments_order = array(
@@ -186,7 +186,7 @@ if (isset($_POST['submit']))
             $order_by = $order_by_inside_category = array_slice($_POST['order_by'], 0, ceil(count($sort_fields)/2));
 
             // there is no rank outside categories
-            if ( ($i = array_search('rank ASC', $order_by)) !== false)
+            if ( ($i = array_search('ima_rank ASC', $order_by)) !== false)
             {
               unset($order_by[$i]);
             }

--- a/admin/element_set_ranks.php
+++ b/admin/element_set_ranks.php
@@ -86,7 +86,7 @@ if (isset($_POST['submit']))
   }
   elseif ($image_order_choice=='rank')
   {
-    $image_order = 'rank ASC';
+    $image_order = 'ima_rank ASC';
   }
   $query = '
 UPDATE '.CATEGORIES_TABLE.' 
@@ -124,7 +124,7 @@ SELECT *
 ;';
 $category = pwg_db_fetch_assoc(pwg_query($query));
 
-if ($category['image_order']=='rank ASC')
+if ($category['image_order']=='ima_rank ASC')
 {
   $image_order_choice = 'rank';
 }
@@ -158,11 +158,11 @@ SELECT
     representative_ext,
     width, height, rotation,
     name,
-    rank
+    ima_rank
   FROM '.IMAGES_TABLE.'
     JOIN '.IMAGE_CATEGORY_TABLE.' ON image_id = id
   WHERE category_id = '.$page['category_id'].'
-  ORDER BY rank
+  ORDER BY ima_rank
 ;';
 $result = pwg_query($query);
 if (pwg_db_num_rows($result) > 0)
@@ -213,7 +213,7 @@ $sort_fields = array(
   'hit ASC'             => l10n('Visits, low &rarr; high'),
   'id ASC'              => l10n('Numeric identifier, 1 &rarr; 9'),
   'id DESC'             => l10n('Numeric identifier, 9 &rarr; 1'),
-  'rank ASC'            => l10n('Manual sort order'),
+  'ima_rank ASC'            => l10n('Manual sort order'),
   );
 
 $template->assign('image_order_options', $sort_fields);

--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -687,9 +687,9 @@ function save_categories_order($categories)
 function update_global_rank()
 {
   $query = '
-SELECT id, id_uppercat, uppercats, rank, global_rank
+SELECT id, id_uppercat, uppercats, cat_rank, global_rank
   FROM '.CATEGORIES_TABLE.'
-  ORDER BY id_uppercat,rank,name';
+  ORDER BY id_uppercat,cat_rank,name';
 
   global $cat_map; // used in preg_replace callback
   $cat_map = array();
@@ -708,8 +708,8 @@ SELECT id, id_uppercat, uppercats, rank, global_rank
     ++$current_rank;
     $cat =
       array(
-        'rank' =>        $current_rank,
-        'rank_changed' =>$current_rank!=$row['rank'],
+        'cat_rank' =>        $current_rank,
+        'rank_changed' =>$current_rank!=$row['cat_rank'],
         'global_rank' => $row['global_rank'],
         'uppercats' =>   $row['uppercats'],
         );
@@ -718,7 +718,7 @@ SELECT id, id_uppercat, uppercats, rank, global_rank
 
   $datas = array();
 
-  $cat_map_callback = function($m) use ($cat_map) {  return $cat_map[$m[1]]["rank"]; };
+  $cat_map_callback = function($m) use ($cat_map) {  return $cat_map[$m[1]]["cat_rank"]; };
 
   foreach( $cat_map as $id=>$cat )
   {
@@ -732,7 +732,7 @@ SELECT id, id_uppercat, uppercats, rank, global_rank
     {
       $datas[] = array(
           'id' => $id,
-          'rank' => $cat['rank'],
+          'cat_rank' => $cat['cat_rank'],
           'global_rank' => $new_global_rank,
         );
     }
@@ -744,7 +744,7 @@ SELECT id, id_uppercat, uppercats, rank, global_rank
     CATEGORIES_TABLE,
     array(
       'primary' => array('id'),
-      'update'  => array('rank', 'global_rank')
+      'update'  => array('cat_rank', 'global_rank')
       ),
     $datas
     );
@@ -1453,7 +1453,7 @@ function create_virtual_category($category_name, $parent_id=null, $options=array
   {
     //what is the current higher rank for this parent?
     $query = '
-SELECT MAX(rank) AS max_rank
+SELECT MAX(cat_rank) AS max_rank
   FROM '. CATEGORIES_TABLE .'
   WHERE id_uppercat '.(empty($parent_id) ? 'IS NULL' : '= '.$parent_id).' 
 ;';
@@ -1467,7 +1467,7 @@ SELECT MAX(rank) AS max_rank
 
   $insert = array(
     'name' => $category_name,
-    'rank' => $rank,
+    'cat_rank' => $rank,
     'global_rank' => 0,
     );
 
@@ -1521,7 +1521,7 @@ SELECT id, uppercats, global_rank, visible, status
     $parent = pwg_db_fetch_assoc(pwg_query($query));
 
     $insert['id_uppercat'] = $parent['id'];
-    $insert['global_rank'] = $parent['global_rank'].'.'.$insert['rank'];
+    $insert['global_rank'] = $parent['global_rank'].'.'.$insert['cat_rank'];
 
     // at creation, must a category be visible or not ? Warning : if the
     // parent category is invisible, the category is automatically create
@@ -1929,9 +1929,9 @@ SELECT
   $query = '
 SELECT
     category_id,
-    MAX(rank) AS max_rank
+    MAX(ima_rank) AS max_rank
   FROM '.IMAGE_CATEGORY_TABLE.'
-  WHERE rank IS NOT NULL
+  WHERE ima_rank IS NOT NULL
     AND category_id IN ('.implode(',', $categories).')
   GROUP BY category_id
 ;';
@@ -1964,7 +1964,7 @@ SELECT
         $inserts[] = array(
           'image_id' => $image_id,
           'category_id' => $category_id,
-          'rank' => $rank,
+          'ima_rank' => $rank,
           );
       }
     }
@@ -3127,12 +3127,12 @@ function save_images_order($category_id, $images)
     $datas[] = array(
       'category_id' => $category_id,
       'image_id' => $id,
-      'rank' => ++$current_rank,
+      'ima_rank' => ++$current_rank,
       );
   }
   $fields = array(
     'primary' => array('image_id', 'category_id'),
-    'update' => array('rank')
+    'update' => array('ima_rank')
     );
   mass_updates(IMAGE_CATEGORY_TABLE, $fields, $datas);
 }

--- a/admin/site_update.php
+++ b/admin/site_update.php
@@ -193,7 +193,7 @@ SELECT id
 
   // let's see if some categories already have some sub-categories...
   $query = '
-SELECT id_uppercat, MAX(rank)+1 AS next_rank
+SELECT id_uppercat, MAX(cat_rank)+1 AS next_rank
   FROM '.CATEGORIES_TABLE.'
   GROUP BY id_uppercat';
   $result = pwg_query($query);
@@ -252,9 +252,9 @@ SELECT id_uppercat, MAX(rank)+1 AS next_rank
         $insert['id_uppercat'] = $parent;
         $insert['uppercats'] =
           $db_categories[$parent]['uppercats'].','.$insert['id'];
-        $insert['rank'] = $next_rank[$parent]++;
+        $insert['cat_rank'] = $next_rank[$parent]++;
         $insert['global_rank'] =
-          $db_categories[$parent]['global_rank'].'.'.$insert['rank'];
+          $db_categories[$parent]['global_rank'].'.'.$insert['cat_rank'];
         if ('private' == $db_categories[$parent]['status'])
         {
           $insert['status'] = 'private';
@@ -267,8 +267,8 @@ SELECT id_uppercat, MAX(rank)+1 AS next_rank
       else
       {
         $insert['uppercats'] = $insert['id'];
-        $insert{'rank'} = $next_rank['NULL']++;
-        $insert['global_rank'] = $insert['rank'];
+        $insert{'cat_rank'} = $next_rank['NULL']++;
+        $insert['global_rank'] = $insert['cat_rank'];
       }
 
       $inserts[] = $insert;
@@ -305,7 +305,7 @@ SELECT id_uppercat, MAX(rank)+1 AS next_rank
     {
       $dbfields = array(
         'id','dir','name','site_id','id_uppercat','uppercats','commentable',
-        'visible','status','rank','global_rank'
+        'visible','status','cat_rank','global_rank'
         );
       mass_inserts(CATEGORIES_TABLE, $dbfields, $inserts);
 

--- a/admin/user_list_backend.php
+++ b/admin/user_list_backend.php
@@ -218,7 +218,7 @@ if (count($user_ids) > 0)
   $query = '
 SELECT
     user_id,
-    GROUP_CONCAT(name ORDER BY name SEPARATOR ", ") AS groups
+    GROUP_CONCAT(name ORDER BY name SEPARATOR ", ") AS groups2
   FROM '.USER_GROUP_TABLE.'
     JOIN '.GROUPS_TABLE.' ON id = group_id
   WHERE user_id IN ('.implode(',', $user_ids).')
@@ -227,7 +227,7 @@ SELECT
   $result = pwg_query($query);
   while ($row = pwg_db_fetch_assoc($result))
   {
-    $groups_of_user[ $row['user_id'] ] = $row['groups'];
+    $groups_of_user[ $row['user_id'] ] = $row['groups2'];
   }
 
   $key_replace = array_search('recent_period', $aColumns);

--- a/include/category_cats.inc.php
+++ b/include/category_cats.inc.php
@@ -64,7 +64,7 @@ $query.= '
 if ('recent_cats' != $page['section'])
 {
   $query.= '
-  ORDER BY rank';
+  ORDER BY cat_rank';
 }
 
 $result = pwg_query($query);

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -127,9 +127,9 @@ DELETE
   if ($search_current_ranks)
   {
     $query = '
-SELECT category_id, MAX(rank) AS max_rank
+SELECT category_id, MAX(cat_rank) AS max_rank
   FROM '.IMAGE_CATEGORY_TABLE.'
-  WHERE rank IS NOT NULL
+  WHERE cat_rank IS NOT NULL
     AND category_id IN ('.implode(',', $new_cat_ids).')
   GROUP BY category_id
 ;';
@@ -755,7 +755,7 @@ SELECT
     image_id
   FROM '.IMAGE_CATEGORY_TABLE.'
   WHERE category_id = '.$params['category_id'].'
-  ORDER BY rank ASC
+  ORDER BY ima_rank ASC
 ;';
     $image_ids = query2array($query, null, 'image_id');
 
@@ -801,7 +801,7 @@ SELECT COUNT(*)
 
   // what is the current higher rank for this category?
   $query = '
-SELECT MAX(rank) AS max_rank
+SELECT MAX(ima_rank) AS max_rank
   FROM '. IMAGE_CATEGORY_TABLE .'
   WHERE category_id = '. $params['category_id'] .'
 ;';
@@ -822,17 +822,17 @@ SELECT MAX(rank) AS max_rank
   // update rank for all other photos in the same category
   $query = '
 UPDATE '. IMAGE_CATEGORY_TABLE .'
-  SET rank = rank + 1
+  SET ima_rank = ima_rank + 1
   WHERE category_id = '. $params['category_id'] .'
-    AND rank IS NOT NULL
-    AND rank >= '. $params['rank'] .'
+    AND ima_rank IS NOT NULL
+    AND ima_rank >= '. $params['rank'] .'
 ;';
   pwg_query($query);
 
   // set the new rank for the photo
   $query = '
 UPDATE '. IMAGE_CATEGORY_TABLE .'
-  SET rank = '. $params['rank'] .'
+  SET ima_rank = '. $params['rank'] .'
   WHERE image_id = '. $params['image_id'] .'
     AND category_id = '. $params['category_id'] .'
 ;';

--- a/install/db/76-database.php
+++ b/install/db/76-database.php
@@ -32,7 +32,7 @@ $upgrade_description = 'Add image_category.rank column';
 // |                            Upgrade content                            |
 // +-----------------------------------------------------------------------+
 
-$query = 'ALTER TABLE '.IMAGE_CATEGORY_TABLE.' add column `rank` mediumint(8) unsigned default NULL';
+$query = 'ALTER TABLE '.IMAGE_CATEGORY_TABLE.' add column `cat_rank` mediumint(8) unsigned default NULL';
 pwg_query($query);
 
 $upgrade_description = $query;

--- a/install/piwigo_structure-mysql.sql
+++ b/install/piwigo_structure-mysql.sql
@@ -42,7 +42,7 @@ CREATE TABLE `piwigo_categories` (
   `id_uppercat` smallint(5) unsigned default NULL,
   `comment` text,
   `dir` varchar(255) default NULL,
-  `rank` smallint(5) unsigned default NULL,
+  `cat_rank` smallint(5) unsigned default NULL,
   `status` enum('public','private') NOT NULL default 'public',
   `site_id` tinyint(4) unsigned default NULL,
   `visible` enum('true','false') NOT NULL default 'true',
@@ -175,7 +175,7 @@ DROP TABLE IF EXISTS `piwigo_image_category`;
 CREATE TABLE `piwigo_image_category` (
   `image_id` mediumint(8) unsigned NOT NULL default '0',
   `category_id` smallint(5) unsigned NOT NULL default '0',
-  `rank` mediumint(8) unsigned default NULL,
+  `ima_rank` mediumint(8) unsigned default NULL,
   PRIMARY KEY  (`image_id`,`category_id`),
   KEY `image_category_i1` (`category_id`)
 ) ENGINE=MyISAM;


### PR DESCRIPTION
rank is replaced by ima_rank for image_category table and by cat_rank
for categories table
Fix was tested successfully on tag 2.9.4 and also on head of master branch
Installation of piwigo is OK
Photos notation is OK
Display photos with best notation is OK