### PR TITLE
issue #1019 photo upload redesign, improved

### DIFF
--- a/admin/include/photos_add_direct_prepare.inc.php
+++ b/admin/include/photos_add_direct_prepare.inc.php
@@ -150,6 +150,15 @@ SELECT category_id
 // existing album
 $template->assign('selected_category', $selected_category);
 
+// how many existing albums?
+$query = '
+SELECT
+    COUNT(*)
+  FROM '.CATEGORIES_TABLE.'
+;';
+list($nb_albums) = pwg_db_fetch_row(pwg_query($query));
+// $nb_albums = 0;
+$template->assign('NB_ALBUMS', $nb_albums);
 
 // image level options
 $selected_level = isset($_POST['level']) ? $_POST['level'] : 0;

--- a/admin/themes/clear/theme.css
+++ b/admin/themes/clear/theme.css
@@ -59,6 +59,7 @@ padding-bottom: 15px; }
 }
 html, body {
 	min-height: 100%;
+  height: 100%;
 	background-color: #fff;
 }
 
@@ -361,7 +362,6 @@ table.dataTable thead th, table.dataTable.no-footer {
 
 .big-progressbar {
   background: #3C3C3C;
-  border: 1px solid #A5A5A5;
 }
 
 .font-checkbox [class*=icon-check]:before { color:#444; }
@@ -408,7 +408,6 @@ a#showPermissions {color: #5B5B5B; border: 1px solid #D6D6D6; background-color: 
 a#showPermissions:hover {border-color: #A5A5A5;}
 .icon-plus.cboxElement {background-color: #F6F6F6;}
 .icon-plus.cboxElement:hover {background-color: #F2F2F2;}
-p#uploadWarningsSummary {color:#3C3C3C;}
 .selectize-control.single .selectize-input {border: 2px solid #FFA646!important; color: #3C3C3C;}
 .selectize-control.single .selectize-input:hover {border-color: #FAC17E!important;}
 .plupload_filelist {scrollbar-color: #CBCBCB #ffffff!important; background-color: #ffffff!important;}
@@ -423,5 +422,5 @@ li.plupload_delete a:hover {background: url("images/cancelhover.svg")!important;
 #addAlbumForm input[name="category_name"]:focus {background-color: #DDDDDD;}
 .buttonSeparator {color: #3C3C3C;}
 #uploadForm li.plupload_droptext {background-color: #F5F5F5!important;}
-
-/* beta-test ends */
+.addFilesButtonChanged {background-color: #E5E5E5;}
+.addFilesButtonChanged:hover {background-color: #BBB;}

--- a/admin/themes/default/js/addAlbum.js
+++ b/admin/themes/default/js/addAlbum.js
@@ -38,12 +38,13 @@ jQuery.fn.pwgAddAlbum = function(options) {
       e.preventDefault();
 
       var parent_id = $albumParent.val(),
-          name = $popup.find('[name=category_name]').val();
-          
-      jQuery('#categoryNameError').toggle(!name);
+      name = $popup.find('[name=category_name]').val();
+
       if (!name) {
+        jQuery('#categoryNameError').css('visibility', 'visible');
         return;
       }
+      jQuery('#categoryNameError').css('visibility', 'hidden');
 
       jQuery.ajax({
         url: 'ws.php?format=json',
@@ -103,13 +104,13 @@ jQuery.fn.pwgAddAlbum = function(options) {
   this.colorbox({
     inline: true,
     href: '#addAlbumForm',
-    width: 650, height: 300,
+    width: 650, height: 'auto',
     onComplete: function() {
       if (!$popup.data('init')) {
         init();
       }
 
-      jQuery('#categoryNameError').hide();
+      jQuery('#categoryNameError').css('visibility','hidden');
       $popup.find('[name=category_name]').val('').focus();
       $albumParent[0].selectize.setValue($target.val() || 0);
     }

--- a/admin/themes/default/theme.css
+++ b/admin/themes/default/theme.css
@@ -661,7 +661,7 @@ img.ui-datepicker-trigger {
 }
 
 #photosAddContent P {
-  margin:0;
+  margin: 0;
 }
 
 #photosAddContent TH {
@@ -677,7 +677,7 @@ img.ui-datepicker-trigger {
   width:50%;
 }
 
-html, body {height:100%; margin:0; padding:0;}
+html, body {height:100; min-height: 100%; margin:0; padding:0;}
 #the_page {min-height:100%; position:absolute; width:100%; padding:0;margin:0;}
 
 #pwgMain {
@@ -1230,8 +1230,8 @@ LEGEND {
 #uploadBoxes {margin-top:20px;}
 #addUploadBox {margin-bottom:2em;}
 
-p.uploadInfo {text-align:left;font-size:90%;color:#999;}
-p#uploadWarningsSummary {text-align:left;margin-bottom:1em;font-size:100%;}
+p.uploadInfo {text-align:left;}
+p#uploadWarningsSummary {text-align:left;}
 p#uploadWarningsSummary .showInfo {margin-left:3px;}
 p#uploadWarnings {display:none;text-align:left;margin-bottom:1em;font-size:90%;color:#999;}
 p#uploadModeInfos {text-align:left;margin-top:1em;font-size:90%;color:#999;}
@@ -1243,7 +1243,7 @@ a#showPermissions:hover {text-decoration: none;}
 #uploadForm .plupload_buttons, #uploadForm .plupload_progress { display:none !important; }
 #uploadForm #startUpload { margin:5px 0 15px 25px; padding:8px 10px; font-size:1.1em; }
 #uploadForm #startUpload:before { margin-right:0.5em;} 
-#uploadForm #addFiles { margin-right:10px; float:left;}
+#uploadForm #addFiles { margin-right:10px; float:left; height: 45.6px;}
 #uploadForm #uploadingActions { margin:10px 10px 10px 15px; }
 #uploadForm .big-progressbar { vertical-align:middle; display:inline-block; margin-left:10px; }
 
@@ -1594,7 +1594,7 @@ fieldset#environment legend i[class*="icon-"] {
   transition: all 125ms ease-out;
 }
 
-#cboxLoadedContent input[type="submit"] {margin-bottom: 30px; float: none;}
+#cboxLoadedContent input[type="submit"] {margin-bottom: 20px; float: none;}
 
 .selectAlbum, #permissions, .selectFiles {border: 0;}
 #permissions {display: none!important;}
@@ -1612,7 +1612,7 @@ fieldset#environment legend i[class*="icon-"] {
 .selectize-control.single .selectize-input {border-radius: 0; font-weight: bold;font-size: 12px;}
 .buttonLike {padding: 8px 10px; margin-left: 5px;}
 .selectFilesButtonBlock {display: flex; margin-top: 10px;}
-.selectFilesinfo {margin-top: 10px; margin-left: 15px;}
+.selectFilesinfo {margin-left: 15px; font-size: 90%; color: #999; display: flex; flex-direction: column; justify-content: center;}
 #uploader {margin-top: 25px; font-weight: bold !important;}
 .plupload_filelist_header {display: none;}
 .plupload_filelist {scrollbar-width: thin!important;}
@@ -1627,16 +1627,16 @@ li.plupload_delete a:hover {background: url("images/cancelhover.svg")!important;
 #photosAddContent .Addedphotos {border: none; margin-top: 35px;}
 .plupload_upload_status {}
 
-.addAlbumEmpty {text-align: center; margin-top: 10%;}
+.addAlbumEmpty {text-align: center; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);}
+.addAlbumEmptyCenter {position: relative; margin: auto; height: calc(100vh - 200px);}
 .addAlbumEmptyTitle {font-size: 35px; font-weight: bold;}
 .addAlbumEmptyInfos {font-size: 14px; margin-bottom: 25px !important; margin-top: 5px !important;}
 .addAlbumEmpty a{display: inline-block; padding: 10px 15px; font-weight: bold; font-size: 14px;}
 .addAlbumEmpty a:hover{text-decoration: none;}
 .addAlbumEmpty a::first-letter {text-transform: capitalize;}
-.addAlbumFormParent {display: none;}
-#cboxLoadedContent {height: auto !important; padding: 20px 20px 30px 20px !important;}
+#cboxLoadedContent {height: auto !important; padding: 20px 20px 20px 20px !important;}
 .buttonSeparator {font-weight: bold;}
-.popinButtons {text-align: right; padding-top: 24px;}
+.popinButtons {text-align: right; margin-top: 24px;}
 .popinButtons input[type="submit"] {margin-right: 0;}
 #albumCreationLoading {
 	background-color: #ffa744;
@@ -1646,7 +1646,7 @@ li.plupload_delete a:hover {background: url("images/cancelhover.svg")!important;
 	font-weight: bold; 
 	display: none;
 }
-.popinField {margin-top: 30px;}
+.popinField {margin-top: 30px; }
 .popinField.addAlbumFormParent {margin-top: 0;}
 .popinFieldLabel {display: block; margin-bottom: 5px;}
 .selectedAlbum {margin-top: 10px; margin-left: 5px;}

--- a/admin/themes/roma/theme.css
+++ b/admin/themes/roma/theme.css
@@ -21,7 +21,7 @@ h2 { color: #ccc; }
   right: 0;
   width: 550px;
 }
-html, body { min-height: 100%; }
+html, body { min-height: 100%; height: 100%;}
 
 body {
 	background-color:#444;
@@ -306,7 +306,6 @@ div.token-input-dropdown ul li.token-input-selected-dropdown-item {background-co
 
 .big-progressbar {
   background: #3c3939;
-  border: 1px solid #3C3C3C;
 }
 
 /* Album Properties */
@@ -401,7 +400,6 @@ a#showPermissions {color: #D6D6D6; border: 1px solid #D6D6D6; background-color: 
 a#showPermissions:hover {border-color: #A5A5A5;}
 .icon-plus.cboxElement {border: 1px solid #777; color: #c0c0c0;}
 .icon-plus.cboxElement:hover {border: 1px solid #aaa;}
-p#uploadWarningsSummary {color:#999;}
 .selectize-control.single .selectize-input {border: 2px solid #FAC17E!important; color: #D5D5D5;}
 .selectize-control.single .selectize-input:hover {border-color: #FFA646!important;}
 .plupload_filelist {background-color: #444444 !important; scrollbar-color: #555 #444444!important;}
@@ -418,3 +416,5 @@ li.plupload_delete a:hover {background: url("images/cancelhover.svg")!important;
 #addAlbumForm {color: #999;}
 .selectedAlbum span {background-color: #555; color: #999;}
 #uploadForm li.plupload_droptext {background-color: #343434!important; color: #777 !important;}
+.addFilesButtonChanged {background-color: #888;}
+.addFilesButtonChanged:hover {background-color: #777;}


### PR DESCRIPTION
* Hide album selection after creation
* Correctly center the welcome box
* Better alignment for select files info
* Remove summary for select files info, always display details
* Fix dynamic margins in album popin
* Simplify show/hide blocks when no album available
* Make file selection button secondary when files added to queue