### PR TITLE
Fix: Unable to add date_creation of non-photos

### DIFF
--- a/admin/include/functions_metadata.php
+++ b/admin/include/functions_metadata.php
@@ -168,6 +168,7 @@ function get_sync_metadata($infos)
 {
   global $conf;
   $file = PHPWG_ROOT_PATH.$infos['path'];
+  $orig_file = $file;
   $fs = @filesize($file);
 
   if ($fs===false)
@@ -194,7 +195,6 @@ function get_sync_metadata($infos)
       }
 
     }
-
     $file = original_to_representative($file, $infos['representative_ext']);
   }
 
@@ -212,13 +212,13 @@ function get_sync_metadata($infos)
 
   if ($conf['use_exif'])
   {
-    $exif = get_sync_exif_data($file);
+    $exif = get_sync_exif_data($orig_file);
     $infos = array_merge($infos, $exif);
   }
 
   if ($conf['use_iptc'])
   {
-    $iptc = get_sync_iptc_data($file);
+    $iptc = get_sync_iptc_data($orig_file);
     $infos = array_merge($infos, $iptc);
   }
 

--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -24,6 +24,8 @@
 include_once(PHPWG_ROOT_PATH.'admin/include/functions.php');
 include_once(PHPWG_ROOT_PATH.'admin/include/image.class.php');
 
+set_time_limit(0);
+
 // add default event handler for image and thumbnail resize
 add_event_handler('upload_image_resize', 'pwg_image_resize');
 add_event_handler('upload_thumbnail_resize', 'pwg_image_resize');
@@ -407,7 +409,6 @@ SELECT
   unset_make_full_url();
 
   fetchRemote($thumb_url, $dest);
-
 
   return $image_id;
 }

--- a/include/functions_metadata.inc.php
+++ b/include/functions_metadata.inc.php
@@ -144,11 +144,6 @@ function get_exif_data($filename, $map)
   
   $result = array();
 
-  if (!function_exists('read_exif_data'))
-  {
-    die('Exif extension not available, admin should disable exif use');
-  }
-
   // Read EXIF data
   if ($exif = @read_exif_data($filename) or $exif2 = trigger_change('format_exif_data', $exif=null, $filename, $map))
   {
@@ -169,7 +164,11 @@ function get_exif_data($filename, $map)
         if (isset($exif[$field]))
         {
           $result[$key] = $exif[$field];
-        }
+	}
+	else if (isset($exif[$key]))
+	{
+	  $result[$key] = $exif[$key];
+	}
       }
       else
       {


### PR DESCRIPTION
`date_creation` is not being added for piwigo-videojs files, so I had to patch the plugin.  Here's a patch for piwigo that will allow it to add `date_creation` to exif even if it's either from `DateTimeOriginal` or `date_creation` when `EXIF` comes from `format_exif_data` trigger.