### PR TITLE
Tags : use math inter char ∩ instead of +

### DIFF
--- a/include/functions_html.inc.php
+++ b/include/functions_html.inc.php
@@ -403,7 +403,7 @@ function get_tags_content_title()
 
   for ($i=0; $i<count($page['tags']); $i++)
   {
-    $title.= $i>0 ? ' + ' : '';
+    $title.= $i>0 ? ' ∩&#x202F;' : '';
 
     $title.=
       '<a href="'

--- a/themes/default/template/menubar_tags.tpl
+++ b/themes/default/template/menubar_tags.tpl
@@ -5,7 +5,7 @@
 		<span>{strip}
 			<a class="tagLevel{$tag.level}" href=
 			{if isset($tag.U_ADD)}
-				"{$tag.U_ADD}" title="{$tag.counter|@translate_dec:'%d photo is also linked to current tags':'%d photos are also linked to current tags'}" rel="nofollow">+
+				"{$tag.U_ADD}" title="{$tag.counter|@translate_dec:'%d photo is also linked to current tags':'%d photos are also linked to current tags'}" rel="nofollow">∩&#x202F;
 			{else}
 				"{$tag.URL}" title="{'display photos linked to this tag'|@translate}">
 			{/if}


### PR DESCRIPTION
What about changing this char ? This helps not to confuse mathematical set theory with mathematical symbol operator. Further more, from set theory, union (+) and intersection (.) can be translated to plus (+) and times (.) operations.