### PR TITLE
(Fix #359) mysqli docs use empty string for no db name

### DIFF
--- a/include/dblayer/functions_mysqli.inc.php
+++ b/include/dblayer/functions_mysqli.inc.php
@@ -47,7 +47,7 @@ function pwg_db_connect($host, $user, $password, $database)
     list($host, $port) = explode(':', $host);
   }
 
-  $dbname = null;
+  $dbname = '';
   
   $mysqli = new mysqli($host, $user, $password, $dbname, $port, $socket);
   if (mysqli_connect_error())


### PR DESCRIPTION
[PHP docs for mysqli's constructor](https://www.php.net/manual/en/mysqli.construct.php) show that the default value for `$dbname` is an empty string. So, if we want to use parameters after `$dbname` in the call without specifying a database name, we should be using an empty string for `$dbname` instead of a `NULL`.