### PR TITLE
Fixes #698: noindex & nofollow non-default picture page state

### DIFF
--- a/picture.php
+++ b/picture.php
@@ -619,7 +619,9 @@ $metadata_showable = trigger_change(
   $picture['current']
   );
 
-if ( $metadata_showable and pwg_get_session_var('show_metadata') )
+// noindex and nofollow the page if the display of metadata will be different
+// than the default state
+if ( $metadata_showable xor pwg_get_session_var('show_metadata') )
 {
   $page['meta_robots']=array('noindex'=>1, 'nofollow'=>1);
 }


### PR DESCRIPTION
We want the default version of picture pages to be indexed by search engines according to the canonical link, and we want to make sure non-default versions of each page are not indexed by search engines.

The picture page contains logic that creates noindex and nofollow attributes to be included if metadata is being displayed. If the theme's settings triggers this behavior by default (for example, using the SimpleNG theme), then that means the webmaster's intended "default" version of the page will not be indexed.

The intent of this PR is to add the noindex and nofollow attributes (in relation to whether metadata is being shown or not) only when the non-default state of the page is being displayed.