### PR TITLE
Fix jshrink file corruption under PHP 7.3

### DIFF
--- a/include/jshrink.class.php
+++ b/include/jshrink.class.php
@@ -192,7 +192,7 @@ class JShrink_Minifier
 				case "\n":
 					// if the next line is something that can't stand alone
                     // preserve the newline
-					if($this->b !== false && strpos('(-+{[@', $this->b) !== false)
+					if($this->b !== false && strpos('(-+{[@', (string)$this->b) !== false)
 					{
 						echo $this->a;
 						$this->saveString();
@@ -216,7 +216,7 @@ class JShrink_Minifier
 					switch($this->b)
 					{
 						case "\n":
-							if(strpos('}])+-"\'', $this->a) !== false)
+							if(strpos('}])+-"\'', (string)$this->a) !== false)
 							{
 								echo $this->a;
 								$this->saveString();
@@ -251,7 +251,7 @@ class JShrink_Minifier
 			// do reg check of doom
 			$this->b = $this->getReal();
 
-			if(($this->b == '/' && strpos('(,=:[!&|?', $this->a) !== false))
+			if(($this->b == '/' && strpos('(,=:[!&|?', (string)$this->a) !== false))
 				$this->saveRegex();
 		}
 		$this->clean();
@@ -260,7 +260,7 @@ class JShrink_Minifier
 	/**
 	 * Returns the next string for processing based off of the current index.
 	 *
-	 * @return string
+	 * @return string|bool
 	 */
 	protected function getChar()
 	{


### PR DESCRIPTION
In PHP 7.3 you will get a warning from strpos() when you pass it
a non-string needle. Since getChar() will return false in some
circumstances, this->a and this->b will be non-strings sometimes
and the warning can end up in the resulting js output causing
syntax errors. In my case it meant that the easyRotate plugin
didn't work because of this bug. With this fix it works fine.