### PR TITLE
Fix count() warning

### DIFF
--- a/include/functions_user.inc.php
+++ b/include/functions_user.inc.php
@@ -170,7 +170,7 @@ function register_user($login, $password, $mail_address, $notify_admin=true, &$e
     );
 
   // if no error until here, registration of the user
-  if (count($errors) == 0)
+  if (empty($errors))
   {
     $insert = array(
       $conf['user_fields']['username'] => pwg_db_real_escape_string($login),


### PR DESCRIPTION
In PHP 7.2 and later you will get a warning if you call count() on null. So either initialize $errors to an empty array here, or use empty() to check it as I have done here.