### PR TITLE
Fixes #1155 - removed deprecated usage of implode

### DIFF
--- a/include/dblayer/functions_mysql.inc.php
+++ b/include/dblayer/functions_mysql.inc.php
@@ -563,13 +563,13 @@ function do_maintenance_all_tables()
 
 function pwg_db_concat($array)
 {
-  $string = implode($array, ',');
+  $string = implode(',', $array);
   return 'CONCAT('. $string.')';
 }
 
 function pwg_db_concat_ws($array, $separator)
 {
-  $string = implode($array, ',');
+  $string = implode(',', $array);
   return 'CONCAT_WS(\''.$separator.'\','. $string.')';
 }
 

--- a/include/dblayer/functions_mysqli.inc.php
+++ b/include/dblayer/functions_mysqli.inc.php
@@ -679,13 +679,13 @@ function do_maintenance_all_tables()
 
 function pwg_db_concat($array)
 {
-  $string = implode($array, ',');
+  $string = implode(',', $array);
   return 'CONCAT('. $string.')';
 }
 
 function pwg_db_concat_ws($array, $separator)
 {
-  $string = implode($array, ',');
+  $string = implode(',', $array);
   return 'CONCAT_WS(\''.$separator.'\','. $string.')';
 }
 


### PR DESCRIPTION
Starting with Php 7.4.0 passing the glue after the pieces (i.e. not using the documented order of parameters) has been deprecated. 