### PR TITLE
add Perl module Mojo::Piwigo::Client and demos

### DIFF
--- a/tools/lib/Mojo/Piwigo/Client.pm
+++ b/tools/lib/Mojo/Piwigo/Client.pm
@@ -1,0 +1,332 @@
+# ABSTRACT: Client for Piwigo's Web Service API
+use 5.024; 
+
+package Mojo::Piwigo::Client {
+    use version 0.77; our $VERSION = version->declare("v0.0.1");
+    use Mojo::Base -base;
+    use Mojo::UserAgent;
+    use Mojo::Exception;
+    use Path::Tiny;
+    use POSIX 'ceil';
+    use namespace::clean;
+
+    has [qw/ user password /];
+    has chunk_size => 1_024_476;
+    has url => sub {
+        Mojo::Piwigo::Client::Exception::Args->raise( "required attribute 'url' missing" );
+    };
+    has ua => sub {
+        my $ua = Mojo::UserAgent->new;
+        $ua->transactor->name( __PACKAGE__ . $VERSION );
+        return $ua;
+    };
+    has endpoint => sub {
+        my $url = Mojo::URL->new( shift->url );
+        $url->path->merge( 'ws.php' );
+        $url->query( 'format=json' );
+        return $url;
+    };
+    has [qw/ _token /];
+    has _needs_token => sub {
+        shift->_token // Mojo::Piwigo::Client::Exception::Args->raise( "session token not set, call login() first" );
+    };
+
+    sub login {
+        my ($self) = @_;
+        my $user = $self->user;
+        my $pass = $self->password;
+        defined $user and defined $pass
+            or Mojo::Piwigo::Client::Exception::Args->raise( "can't call login() without user and password set" );
+
+        $self->call( 'pwg.session.login', username => $user, password => $pass );
+
+        my $res = $self->status;
+        if( $res->{status} eq 'guest' ) {
+            Mojo::Piwigo::Client::Exception::Args->raise( "login failed, wrong username or password" );
+        }
+        $self->_token( $res->{pwg_token} );
+        return $self;
+    }
+
+    sub logout {
+        my ($self) = @_;
+        $self->call_res( 'pwg.session.logout' );
+        $self->_token( undef );
+        return $self;
+    }
+
+    sub status {
+        return shift->call_res( 'pwg.session.getStatus' );
+    }
+
+    sub add_category {
+        my ($self, $name) = (shift, shift);
+        return $self->call_res( 'pwg.categories.add', @_, name =>  $name)->{id};
+    }
+
+    sub categories {
+        my ($self, %args) = @_;
+        my $res = $self->call_res( 'pwg.categories.getList', %args );
+        # Fix API brain damage
+        return $args{tree_output} ? $res : $res->{categories};
+    }
+
+    sub upload {
+        my ($self, $filename, $albumid, $progress_cb, %args) = @_;
+        my $chunk_size = $self->chunk_size;
+
+        my $path = path( $filename );
+        $path->is_file or Mojo::Piwigo::Client::Exception::Args->raise(
+            "$path is not a plain file"
+        );
+
+        my $size = -s $path or Mojo::Piwigo::Client::Exception::Args->raise(
+            "file $path is empty"
+        );
+
+        my $fh = $path->openr_raw or Mojo::Piwigo::Client::Exception::Args->raise(
+            "error opening $path for reading: $!"
+        );
+
+        my $nchunks = ceil( $size / $chunk_size ); 
+        my $chunk = 0;
+        my $read_total = 0;
+        while( $chunk < $nchunks ) {
+            $progress_cb->( $filename, $albumid, $chunk, $nchunks ) if $progress_cb;
+
+            my $read = sysread( $fh, my $filedata, $chunk_size, 0) // Mojo::Piwigo::Client::Exception::Request->raise(
+                "read error on $path: $!"
+            );
+            $read_total += $read;
+
+            my $tx = $self->call( 'pwg.images.upload',
+                %args,
+                chunk => $chunk,
+                chunks => $nchunks,
+                category => $albumid,
+                file => { content => $filedata },
+                name => $path->basename,
+                $self->_token_args,
+            );
+            $tx->res->code == 200 or Mojo::Piwigo::Client::Exception::Request->raise(
+                "server error: " . $tx->res->code . ' ' . $tx->res->message
+            );
+            $chunk++;
+        }
+
+        $read_total == $size or Mojo::Piwigo::Client::Exception::Request->raise(
+            "short read on $path: expected $size bytes but read only $read_total"
+        );
+
+        return $self;
+    }
+
+    sub get_images {
+        return shift->call_res( 'pwg.categories.getImages', @_ );
+    }
+
+    sub call_res {
+        my $self = shift;
+        my $tx = $self->call( @_ );
+        my $result = $tx->result->json or Mojo::Piwigo::Client::Exception::Request->raise(
+            "missing result from $_[0], server said: " . $tx->res->code . ' ' . $tx->res->message
+        );
+        $result->{stat} eq 'ok' or Mojo::Piwigo::Client::Exception::Request->raise(
+            "server returned failure: $result->{err} $result->{message}"
+        );
+        return $result->{result};
+    }
+
+    sub call {
+        my ($self, $method, %formargs) = @_;
+        return $self->ua->post( $self->endpoint, form => { %formargs, method => $method } );
+    }
+
+    sub call_p {
+        my ($self, $method, %formargs) = @_;
+        return $self->ua->post_p( $self->endpoint, form => { %formargs, method => $method } );
+    }
+
+    # If login token is present, return pwg_token => $token; otherwise an empty list
+    sub _token_args {
+        my $token = shift->_token;
+        return ( pwg_token => $token ) x !!$token;
+    }
+}
+
+package Mojo::Piwigo::Client::Exception::Args { use Mojo::Base 'Mojo::Exception'; }
+package Mojo::Piwigo::Client::Exception::Request { use Mojo::Base 'Mojo::Exception'; }
+
+1;
+__END__
+
+=head1 SYNOPSIS
+
+    use Mojo::Piwigo::Client;
+
+    # Instantiate a client
+    my $cl = Mojo::Piwigo::Client->new(
+        url => 'https://my.piwigo.org/',
+        user => 'username',
+        password => 'secret'
+    );
+    # Adjust some things about the user agent
+    $cl->ua->request_timeout( 20 );
+    $cl->login;
+    # Upload local files to album #42
+    $cl->upload( $_, 42 ) for qw/ foo.jpg bar.jpg /;
+    $cl->logout;
+
+=head1 DESCRIPTION
+
+This module provides a Perl interface to Piwigo's web service. So far, only a
+few API methods are supported with individual Perl methods, but a
+general-purpose method call is available to call every possible web service
+method.
+
+All methods return C<$self> to allow method chaining unless otherwise
+specified. All methods also throw an exception if there should be a server
+error either on the HTTP or the web service level.
+
+=head1 ATTRIBUTES
+
+=head2 url
+
+The URL for your Piwigo server. This is the only attribute required for basic operation.
+
+=head2 user
+
+User name on your Piwigo server
+
+=head2 password
+
+Password for C<user>.
+
+=head2 chunk_size
+
+When uploading images, use chunks of this size so as not to run into potential
+web server limitations with big pictures. Defaults to 1 MB.
+
+=head2 ua
+
+A L<Mojo::UserAgent> object that will usually be built for you.
+
+=head2 endpoint
+
+A L<Mojo::URL> object describing the WS query endpoint. Built from C<url> and
+best treated as read-only.
+
+=head1 METHODS
+
+Generally, methods take required arguments as positional parameters and accept
+any optional ones as additional hash-style arguments. In keeping with L<Mojo>
+conventions, the constructor wants I<all> hash-style arguments though.
+
+=head2 new
+
+    $cl = Mojo::Piwigo::Client->new( url => 'https://...', user => $u, password => $p );
+
+The only required argument for the constructor (unless you want to set it
+later, but why would you?) is C<url>. However, you'll likely want to add
+C<user> and C<password> because many methods require a login.
+
+=head2 login
+
+    $cl->login;
+
+Log in to the server. Requires C<user> and C<password> to be set and will throw
+an exception if they are not.
+
+=head2 logout
+
+    $cl->logout;
+
+Terminate the current session.
+
+=head2 status
+
+    $s = $cl->status;
+
+Returns a reference to a hash of various tidbits about your session, see
+C<pwg.session.getStatus>.
+
+=head2 upload
+
+    $cl->upload( '$file.jpg', 42 );
+    $cl->upload( '$file.jpg', 42,
+        sub { printf("Uploading chunk %d/%d of file %s to album #%d\n", @_[2,3,0,1]);
+        }
+    );
+    $cl->upload( '$file.jpg', 42, undef, level => 8 );
+
+Upload an image to an album specified by ID. You'll usually want to call
+L<login> first unless your server is very permissive.
+
+The two requires arguments are a locally accessible image file name and an
+album ID. A third argument may be a callback that will be called once for every
+chunk uploaded. Further arguments to C<pwg.images.upload> may be specified
+hash-style.
+
+=head2 add_category
+
+    $id = $cl->add_category( "My album" );
+    $id = $cl->add_category( "My album",
+        parent => 42,
+        comment => "Nothing to see here"
+    );
+
+Add a category and return its numeric ID.
+
+=head2 categories
+
+    $catlist = $cl->categories;
+    $catlist = $cl->categories(
+        cat_id => 42,
+        recursive => 1,
+    );
+
+Returns a reference to a list of categories, each represented as a hash.
+
+=head2 get_images
+
+    $imgs = $cl->get_images;
+    $imgs = $cl->get_images( cat_id => 42 );
+
+Get a list of images, optionally restricted to a certain category.
+
+=head2 call_res
+
+    $result = $cl->call_res( 'pwg.categories.setInfo',
+        category_id => 42,
+        comment => 'There are many albums, but this one is mine!'
+    );
+
+Call a method and return its result if the server returned success, otherwise
+an exception is thrown.
+
+=head2 call
+
+    $tx = $cl->call( $method, %args );
+    $tx->res->code == 200 or die "b0rk: " . $tx->res->message;
+
+Call a method and return a L<Mojo::Transaction::HTTP> object representing the
+result. Use this if you want to look at the raw HTTP result codes and such.
+
+=head2 call_p
+
+An asnynchronous version of L</call>, returns a L<Mojo::Promise>. Experimental.
+
+=head1 BUGS
+
+Probably. At the very least, exception handling needs improving and documentation.
+
+=head1 AUTHOR
+
+Matthias Bethke <mbethke@cpan.org>
+
+=head1 SEE ALSO
+
+Mojo::Piwigo::Client is based on the L<Mojo> framework, see there for details.
+
+=cut
+

--- a/tools/lib/Mojo/Piwigo/Client/Config.pm
+++ b/tools/lib/Mojo/Piwigo/Client/Config.pm
@@ -1,0 +1,87 @@
+use 5.024; 
+package Mojo::Piwigo::Client::Config {
+    use strict;
+    use warnings;
+    use Try::Tiny;
+    use YAML::XS ();
+
+    use constant DEFAULT_CONFIG => "$ENV{HOME}/.config/piwigo/client.yaml";
+    use constant REQUIRED_ARGS => [ qw/ url user password / ];
+
+    sub new {
+        my $class = shift;
+        my %opts = @_%2 ? $_[0]->%* : @_;
+
+        my $cfg = try {
+            YAML::XS::LoadFile( delete $opts{config} // DEFAULT_CONFIG );
+        } catch {
+            {}
+        };
+
+        %opts = (
+            %$cfg,
+            map { $_ => $opts{$_} } grep { defined $opts{$_} } REQUIRED_ARGS->@*
+        );
+        my @missing = grep { not defined $opts{$_} } REQUIRED_ARGS->@*;
+        @missing and die "required arguments missing: " . join(", ", @missing) . "\n";
+
+        return bless { cfg => \%opts, }, $class;
+    }
+
+    sub cfg {
+        return shift->{cfg}->%*;
+    }
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+    use Mojo::Piwigo::Client;
+    use Mojo::Piwigo::Client::Config;
+
+    # Instantiate a client
+    my $config = Mojo::Piwigo::Client::Config->new( \%options );
+    my $cl = Mojo::Piwigo::Client->new( $config->cfg );
+
+=head1 DESCRIPTION
+
+This is a trivial config file class to simplify passing constructor
+arguments to L<Mojo::Piwigo::Client>. Its constructor takes a hash (inline or
+as a reference) that may contain the keys C<url>, C<user>, C<password>,
+and C<config>. If C<config> is defined, it specifies the path to a
+YAML config file to load; it defaults to C<$HOME/.config/piwigo/client.yaml>.
+
+The config file must contain a hash with any of the first three keys, e.g.
+
+    ---
+    url: https://my.piwigo.org/
+    user: itsme
+    password: seeeecret!
+
+Any values in the constructor arguments overwrite the defaults in the config file.
+Unless all three required arguments are defined in the union of the config file
+and the constructor arguments, an exception will be thrown.
+
+=over 4
+
+url user password parent
+
+=back
+
+=head1 ATTRIBUTES
+
+=head2 cfg
+
+The only attribute, contains a hash of the keys merged constructor arguments
+and the config file. You can pass this directly to L<Mojo::Piwigo::Client/new>,
+see L</SYNOPSIS>.
+
+=head1 AUTHOR
+
+Matthias Bethke <mbethke@cpan.org>
+
+=cut
+

--- a/tools/mojo_upload_dirs.pl
+++ b/tools/mojo_upload_dirs.pl
@@ -1,0 +1,144 @@
+#!/usr/bin/perl
+ 
+# Usage
+# mojo_upload_dirs.pl [--cfg=cfgfile] --url=URL --user=ADMIN --password=PW --parent=name <dir>
+ 
+use 5.024; 
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Mojo::Piwigo::Client;
+use Mojo::Piwigo::Client::Config;
+use Getopt::Long 'GetOptionsFromArray';
+use List::Util qw/ all first /;
+use Path::Tiny;
+use Try::Tiny;
+use IO::Handle;
+use YAML::XS qw/LoadFile Dump/;
+
+exit run( @ARGV );
+
+sub run {
+    my @args = @_;
+    my %opt;
+
+    GetOptionsFromArray(\@args, \%opt,
+        qw/
+
+        config|c=s
+        parent|p=s
+        url|U=s
+        user|u=s
+        password|p=s
+
+        /
+    );
+
+    my $cfg = try {
+        Mojo::Piwigo::Client::Config->new( \%opt );
+    } catch {
+        say STDERR $_;
+        usage(1);
+    };
+
+    my $cl = Mojo::Piwigo::Client->new( $cfg->cfg )->login;
+
+    my $parent_id = get_parent_id( $cl, $opt{parent} );
+    upload_hierarchy( $cl, $_, $parent_id ) for @args;
+    return 0;
+}
+
+# Given a Piwigo client, directory and a parent album, upload the directory and
+# all its subdirectories, reproducing the directory structure as albums
+sub upload_hierarchy {
+    my ($cl, $dir, $parent_id) = @_;
+    my $root = path( $dir );
+    unless( $root->is_dir ) {
+        say STDERR "$dir is not a directory, skipping";
+        return;
+    }
+    recurse_dir( $cl, $root, $parent_id );
+}
+
+# The actual uploading function. Traverses a directory, creates all
+# subdirs as albums, and uploads all JPEG files.
+# TODO: configurable filter instead of hardcoded JPEG-only
+sub recurse_dir {
+    my ($cl, $root, $parent_id) = @_;
+    my %cats = map { $_->{name} => $_->{id} } $cl->categories( cat_id => $parent_id )->@*;
+    my $it = $root->iterator;
+    while( my $p = $it->() ) {
+        if( $p->is_dir ) {
+            my $rel = $p->relative( $root );
+            my $id = $cats{"$rel"} //= $cl->add_category( "$rel", parent => $parent_id );
+            say "DIR: $p => $id";
+            recurse_dir( $cl, $p, $id );
+        } else {
+            STDOUT->printflush( "UPLOAD: $p" );
+            unless( "$p" =~ /\.jpe?g$/i ) {
+                STDOUT->printflush( "wrong type, skipped\n" );
+                next;
+            }
+            try {
+                $cl->upload( "$p", $parent_id, sub {
+                        STDOUT->printflush( ( $_[2] == $_[3]-1 ) ? "\n" : ".");
+                    }
+                );
+            } catch {
+                STDOUT->printflush( "error: $_\n" );
+            };
+        }
+    }
+}
+
+# Given a Piwigo client and the value of the --parent option, figures
+# out the right ID:
+# * If the option is undefined, just return 0, i.e. "no parent"
+# * If the option is a number and corresponds to an existing album ID,
+#   just return it.
+# * Otherwise, interpret the ID as a path separated by slashes (e.g.
+#   "Community/My Album/foo"), try to look that up in the album hierarchy
+#   and return its ID.
+# * Failing that, check whether the option uniquely identifies an album
+#   anywhere in the hierarchy, and if so, return its ID.
+sub get_parent_id {
+    my ($cl, $opt) = @_;
+
+    return 0 unless defined $opt;
+
+    my @flatcats = $cl->categories( recursive => 1 )->@*;
+    $opt =~ /^[0-9]+$/
+        and first { $_->{id} == $opt } @flatcats
+        and return $opt;
+
+    my @path = split /\//, $opt;
+    my $id = descend_album_path(
+        [ split /\//, $opt ],
+        $cl->categories( recursive => 1, tree_output => 1 )
+    );
+    return $id if defined $id;
+    my @matching = grep { $_->{name} == $opt } @flatcats;
+    return $matching[0]{id} if @matching == 1;
+    die "could not find parent album $opt\n";
+}
+
+# Given an array of path components and an array tree of albums,
+# walk the tree according to the path and return the final ID
+sub descend_album_path {
+    my ($path, $cats) = @_;
+    my $name = shift @$path;
+    my $cat = first { $_->{name} eq $name } @$cats
+        or die "no category found for path component $name\n";
+    return $cat->{id} unless @$path;
+    return descend_album_path( $path, $cat->{sub_categories} );
+}
+
+# Print program usage and exit with the argument value
+sub usage {
+    my ($prog) = $0 =~ m!(?:.*/)?(.*)!;
+    print <<EOF;
+Usage: $prog --url=URL --user=NAME --password=PW --album_id=ID <file>
+EOF
+    exit(shift // 0);
+}

--- a/tools/mojo_uploader.pl
+++ b/tools/mojo_uploader.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+ 
+# Usage:
+# mojo_uploader [--config=cfgfile] --url=http://piwigo.org/demo --user=admin --password=secret --album_id=9 photo.jpg ...
+ 
+use 5.024; 
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Mojo::Piwigo::Client;
+use Mojo::Piwigo::Client::Config;
+use Getopt::Long 'GetOptionsFromArray';
+use List::Util qw/ all /;
+use Try::Tiny;
+use YAML::XS 'LoadFile';
+
+exit run( @ARGV );
+
+sub run {
+    my @args = @_;
+    my %opt;
+
+    GetOptionsFromArray(\@args, \%opt,
+        qw/
+
+        config|c=s
+        album_id|a=i
+        url|U=s
+        username|u=s
+        password|p=s
+
+        /
+    );
+
+    unless( @args >= 1 ) {
+        say STDERR "Specify at least one file to upload";
+        usage(1);
+    }
+
+    my $cfg = try {
+        Mojo::Piwigo::Client::Config->new( \%opt );
+    } catch {
+        say STDERR $_;
+        usage(1);
+    };
+    my $cl = Mojo::Piwigo::Client->new(
+        Mojo::Piwigo::Client::Config->new( \%opt )->cfg
+    );
+    $cl->ua->request_timeout( 20 );
+    $cl->login;
+    $cl->upload( $_, $opt{album_id} ) for @args;
+    $cl->logout;
+}
+
+# Print program usage and exit with the argument value
+sub usage {
+    my ($prog) = $0 =~ m!(?:.*/)?(.*)!;
+    print <<EOF;
+Usage: $prog --url=URL --user=NAME --password=PW --album_id=ID <file>
+EOF
+    exit(shift // 0);
+}


### PR DESCRIPTION
I'm glad to see Piwigo has a lot of Perl tooling, but TBH the whole collection has a bit of a 90s feel to it; we've had much simpler and more flexible tools than the venerable workhorse `LWP` for a couple of years now, such as [Mojo](https://metacpan.org/pod/Mojo::UserAgent). So when I started hacking on `piwigo_upload.pl` to fix some weird server errors I'd been getting, I quickly decided to write a new module based on that, `Mojo::Piwigo::Client`.
Here's a first draft that does a few things plus two demos roughly equivalent to some included tools.
Only a few methods are implemented, but I'm not sure it's worth adding them all as you can always use `call_res` to call any method and receive the result as a Perl data structure. Ideas welcome--autogenerating methods from the reflection API would work, too ;)

Additionally, there's a trivial little config module, `Mojo::Piwigo::Client::Config`, that allows you to stick your credentials in a YAML file and forget about them instead of specifying them on the commandline every time, while still making it possible to override the store ones from the commandline when needed.