### PR TITLE
Fix version comparison for session ID regen

### DIFF
--- a/include/functions_user.inc.php
+++ b/include/functions_user.inc.php
@@ -936,10 +936,7 @@ function log_user($user_id, $remember_me)
   if ( session_id()!="" )
   { // we regenerate the session for security reasons
     // see http://www.acros.si/papers/session_fixation.pdf
-    if (version_compare(PHP_VERSION, '7') >= 0)
-    {
-      session_regenerate_id(true);
-    }
+    session_regenerate_id(true);
   }
   else
   {

--- a/include/functions_user.inc.php
+++ b/include/functions_user.inc.php
@@ -936,7 +936,7 @@ function log_user($user_id, $remember_me)
   if ( session_id()!="" )
   { // we regenerate the session for security reasons
     // see http://www.acros.si/papers/session_fixation.pdf
-    if (version_compare(PHP_VERSION, '7') <= 0)
+    if (version_compare(PHP_VERSION, '7') >= 0)
     {
       session_regenerate_id(true);
     }


### PR DESCRIPTION
The comparison should be the other way around for PHP version comparison. session_regenerate_id() was available in 7.0.0 and newer versions. version_compare returns 0 on equality by default, and 1 when the first argument is greater than the second argument.