### PR TITLE
Sort filters by localized name

### DIFF
--- a/admin/batch_manager_global.php
+++ b/admin/batch_manager_global.php
@@ -454,7 +454,11 @@ if ($conf['enable_synchronization'])
 }
 
 $prefilters = trigger_change('get_batch_manager_prefilters', $prefilters);
-usort($prefilters, 'UC_name_compare');
+
+// Sort prefilters by localized name.
+usort($prefilters, function ($a, $b) {
+  return strcmp(strtolower($a['NAME']), strtolower($b['NAME']));
+});
 
 $template->assign(
   array(


### PR DESCRIPTION
The `UC_name_compare` function isn't defined, but was being used
to sort the prefilter list. This change adds a anonymous function
to do the sort comparison (on the filters' NAME attribute).