### PR TITLE
Issue 1195: Add $info as the second parameter for trigger_change 'render_element_name'

### DIFF
--- a/include/functions_html.inc.php
+++ b/include/functions_html.inc.php
@@ -521,7 +521,7 @@ function render_element_name($info)
 {
   if (!empty($info['name']))
   {
-    return trigger_change('render_element_name', $info['name']);
+    return trigger_change('render_element_name', $info['name'], $info);
   }
   return get_name_from_file($info['file']);
 }

--- a/tools/triggers_list.php
+++ b/tools/triggers_list.php
@@ -732,7 +732,7 @@ array(
 array(
   'name' => 'render_element_name',
   'type' => 'trigger_change',
-  'vars' => array('string', 'element_name'),
+  'vars' => array('string', 'element_name', 'array', 'info'),
   'files' => array('include\functions_html.inc.php (render_element_name)'),
 ),
 array(


### PR DESCRIPTION
Fixes #1195 Pass `$info` in `render_element_name`.

This is consistent with what `trigger_change` `'get_thumbnail_title'` does:

https://github.com/Piwigo/Piwigo/blob/5bf85c982b2b7f3e63fefb2d8cfea7a8bcc9e591/include/functions_html.inc.php#L586

It will not break existing usages as it is passed as a second parameter.