### PR TITLE
Fix stored xss 

### DIFF
--- a/admin/cat_list.php
+++ b/admin/cat_list.php
@@ -159,7 +159,7 @@ if (isset($_GET['delete']) and is_numeric($_GET['delete']))
 elseif (isset($_POST['submitAdd']))
 {
   $output_create = create_virtual_category(
-    $_POST['virtual_name'],
+    strip_tags($_POST['virtual_name']),
     @$_GET['parent_id']
   );
 


### PR DESCRIPTION
Saw a Stored XSS while creating an album with the name as that of the following payload at the following endpoint,

Endpoint:- */admin.php?page=cat_list*
Payload:- *<script>alert('xss')</script>*

POC Demo:- [Demo](https://drive.google.com/file/d/1B3yip5wqYOXUESLCANWnuY45nBMKuysK/view?usp=sharing)

Fixed it by wrapping *virtual_name* post parameter inside strip_tags function. 
Please review.