### PR TITLE
A couple of minor PHP 8 fixes that can be applied now

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -237,6 +237,13 @@ if ($nb_photos_in_caddie > 0)
       'U_CADDIE' => $link_start.'batch_manager&amp;filter=prefilter-caddie',
       )
     );
+} else {
+  $template->assign(
+    array(
+      'NB_PHOTOS_IN_CADDIE' => 0,
+      'U_CADDIE' => '',
+      )
+    );
 }
 
 // any photos with no md5sum ?
@@ -259,6 +266,13 @@ if ($nb_orphans > 0)
     array(
       'NB_ORPHANS' => $nb_orphans,
       'U_ORPHANS' => $link_start.'batch_manager&amp;filter=prefilter-no_album',
+      )
+    );
+} else {
+  $template->assign(
+    array(
+      'NB_ORPHANS' => 0,
+      'U_ORPHANS' => '',
       )
     );
 }

--- a/admin/batch_manager_global.php
+++ b/admin/batch_manager_global.php
@@ -486,6 +486,8 @@ if (isset($page['no_md5sum_number']))
       'NB_NO_MD5SUM' => $page['no_md5sum_number'],
     )
   );
+} else {
+  $template->assign('NB_NO_MD5SUM', '');
 }
 
 // +-----------------------------------------------------------------------+

--- a/admin/include/c13y_internal.class.php
+++ b/admin/include/c13y_internal.class.php
@@ -66,7 +66,7 @@ class c13y_internal
 
     foreach (array('show_exif', 'use_exif') as $value)
     {
-      if (($conf[$value]) and (!function_exists('read_exif_data')))
+      if (($conf[$value]) and (!function_exists('exif_read_data')))
       {
         $c13y->add_anomaly(
           sprintf(l10n('%s value is not correct file because exif are not supported'), '$conf[\''.$value.'\']'),

--- a/admin/include/functions_upgrade.php
+++ b/admin/include/functions_upgrade.php
@@ -212,7 +212,7 @@ SELECT status
   $username = $_POST['username'];
   $password = $_POST['password'];
 
-  if(!@get_magic_quotes_gpc())
+  if(function_exists('get_magic_quotes_gpc') && !@get_magic_quotes_gpc() )
   {
     $username = pwg_db_real_escape_string($username);
   }

--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -371,7 +371,7 @@ SELECT
   }
 
   // update metadata from the uploaded file (exif/iptc)
-  if ($conf['use_exif'] and !function_exists('read_exif_data'))
+  if ($conf['use_exif'] and !function_exists('exif_read_data'))
   {
     $conf['use_exif'] = false;
   }

--- a/admin/include/photos_add_direct_prepare.inc.php
+++ b/admin/include/photos_add_direct_prepare.inc.php
@@ -191,7 +191,7 @@ if (!isset($_SESSION['upload_hide_warnings']))
 {
   $setup_warnings = array();
   
-  if ($conf['use_exif'] and !function_exists('read_exif_data'))
+  if ($conf['use_exif'] and !function_exists('exif_read_data'))
   {
     $setup_warnings[] = l10n('Exif extension not available, admin should disable exif use');
   }

--- a/admin/intro.php
+++ b/admin/intro.php
@@ -167,6 +167,8 @@ SELECT COUNT(*)
 ;';
   list($nb_comments) = pwg_db_fetch_row(pwg_query($query));
   $template->assign('NB_COMMENTS', $nb_comments);
+} else {
+  $template->assign('NB_COMMENTS', 0);
 }
 
 if ($nb_photos > 0)

--- a/include/common.inc.php
+++ b/include/common.inc.php
@@ -17,7 +17,7 @@ $t2 = microtime(true);
 // addslashes to vars if magic_quotes_gpc is off this is a security
 // precaution to prevent someone trying to break out of a SQL statement.
 //
-if( !@get_magic_quotes_gpc() )
+if(function_exists('get_magic_quotes_gpc') && !@get_magic_quotes_gpc() )
 {
   function sanitize_mysql_kv(&$v, $k)
   {

--- a/include/functions_metadata.inc.php
+++ b/include/functions_metadata.inc.php
@@ -129,13 +129,13 @@ function get_exif_data($filename, $map)
   
   $result = array();
 
-  if (!function_exists('read_exif_data'))
+  if (!function_exists('exif_read_data'))
   {
     die('Exif extension not available, admin should disable exif use');
   }
 
   // Read EXIF data
-  if ($exif = @read_exif_data($filename) or $exif2 = trigger_change('format_exif_data', $exif=null, $filename, $map))
+  if ($exif = @exif_read_data($filename) or $exif2 = trigger_change('format_exif_data', $exif=null, $filename, $map))
   {
     if (!empty($exif2))
     {

--- a/include/picture_metadata.inc.php
+++ b/include/picture_metadata.inc.php
@@ -13,7 +13,7 @@
 
 
 include_once(PHPWG_ROOT_PATH.'/include/functions_metadata.inc.php');
-if (($conf['show_exif']) and (function_exists('read_exif_data')))
+if (($conf['show_exif']) and (function_exists('exif_read_data')))
 {
   $exif_mapping = array();
   foreach ($conf['show_exif_fields'] as $field)

--- a/install.php
+++ b/install.php
@@ -14,7 +14,7 @@ define('PHPWG_ROOT_PATH','./');
 // addslashes to vars if magic_quotes_gpc is off this is a security
 // precaution to prevent someone trying to break out of a SQL statement.
 //
-if( !@get_magic_quotes_gpc() )
+if(function_exists('get_magic_quotes_gpc') && !@get_magic_quotes_gpc() )
 {
   if( is_array($_POST) )
   {

--- a/tools/metadata.php
+++ b/tools/metadata.php
@@ -75,7 +75,7 @@ else
 
 echo '<br><br><br>';
 echo 'EXIF Fields in '.$filename.'<br>';
-$exif = read_exif_data($filename);
+$exif = exif_read_data($filename);
 echo '<pre>';
 print_r($exif);
 echo '</pre>';


### PR DESCRIPTION
- Use `exif_read_data()` instead of the deprecated `read_exif_data()` alias
- Initialize a couple of uninitialized template variables