### PR TITLE
Check the X-Forwarded-Proto header for HTTPS

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -37,8 +37,11 @@ function get_absolute_root_url($with_scheme=true)
   if ($with_scheme)
   {
     $is_https = false;
-    if (isset($_SERVER['HTTPS']) &&
-      ((strtolower($_SERVER['HTTPS']) == 'on') or ($_SERVER['HTTPS'] == 1)))
+    $server_https = isset($_SERVER['HTTPS']) &&
+      ((strtolower($_SERVER['HTTPS']) == 'on') or ($_SERVER['HTTPS'] == 1));
+    $server_forwarded_https = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+      strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https';
+    if ($server_https or $server_forwarded_https)
     {
       $is_https = true;
       $url .= 'https://';


### PR DESCRIPTION
Should fix issues like https://github.com/Piwigo/Piwigo-Android/issues/184 all proper-like.

Currently, Piwigo only uses a HTTPS URL scheme if PHP's `$_SERVER['HTTPS']` variable returns true but this usually isn't the case where a reverse proxy is involved. In those cases, the server can set `X-Forwarded-Proto`.