### PR TITLE
Fix missing thumbnail for TIFF images.

### DIFF
--- a/admin/comments.php
+++ b/admin/comments.php
@@ -172,6 +172,7 @@ while ($row = pwg_db_fetch_assoc($result))
       array(
         'id'=>$row['image_id'],
         'path'=>$row['path'],
+        'representative_ext'=>$row['representative_ext'],
         )
      );
   if (empty($row['author_id']))


### PR DESCRIPTION
Without this, the thumbnail is replaced with unknown MIME icon.