### PR TITLE
Convert uploaded TIFF and delete the original

### DIFF
--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -339,6 +339,7 @@ SELECT
     {
       unlink($file_path);
       $file_path = $upload_dir.'/pwg_representative/'.$filename_wo_ext.'.' .$representative_ext;
+      $representative_ext = null;
     }
     
     $insert = array(

--- a/admin/include/image.class.php
+++ b/admin/include/image.class.php
@@ -58,7 +58,7 @@ class pwg_image
 
     $extension = strtolower(get_extension($source_filepath));
 
-    if (!in_array($extension, array('jpg', 'jpeg', 'png', 'gif')))
+    if (!in_array($extension, array('jpg', 'jpeg', 'png', 'gif', 'tif', 'tiff')))
     {
       die('[Image] unsupported file extension');
     }


### PR DESCRIPTION
1. Allow resizing TIFF 
2. Delete uploaded TIFF after the representative is made.
3. Register the representative as new "original".

Web browsers cannot display TIFF, so it is waste of space to keep them. This patch does only apply to new uploads.