### PR TITLE
Add last calculated cache size to Dashboard Storage chart

### DIFF
--- a/admin/intro.php
+++ b/admin/intro.php
@@ -423,6 +423,19 @@ if (isset($result[0]['SUM(filesize)']))
   $data_storage['Formats'] = $result[0]['SUM(filesize)'];
 }
 
+// Add cache size if requested and known.
+if ($conf['add_cache_to_storage_chart'] && isset($conf['cache_sizes']))
+{
+  $cache_sizes = unserialize($conf['cache_sizes']);
+  if (isset($cache_sizes))
+  {
+    if (isset($cache_sizes[0]) && isset($cache_sizes[0]['value']))
+    {
+      $data_storage['Cache'] = $cache_sizes[0]['value']/1024;
+    }
+  }
+}
+
 //Calculate total storage
 $total_storage = 0;
 foreach ($data_storage as $value) 

--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -734,6 +734,10 @@ $conf['album_move_delay_before_auto_opening'] = 3*1000;
 // This variable is used to show or hide the template tab in the side menu
 $conf['show_template_in_side_menu'] = false;
 
+// Add last calculated cache size to Dashboard Storage chart if true.
+// To recalculate use Tools -> Maintenance, Refresh.
+$conf['add_cache_to_storage_chart'] = false;
+
 // +-----------------------------------------------------------------------+
 // | Filter                                                                |
 // +-----------------------------------------------------------------------+


### PR DESCRIPTION
Size of cached files with all derivates and representatives may be
as large as all image files, actually doubling the needed storage
size. So it may be nice to see it represented in the storage
chart, if one remembers to occasionally recalculate it under
Tools -> Maintenance..

To not have this mis-representation active for non-aware users,
make it a configuration switch defaulting to false.
