### PR TITLE
Add option to turn off display_errors

### DIFF
--- a/include/common.inc.php
+++ b/include/common.inc.php
@@ -85,7 +85,10 @@ include(PHPWG_ROOT_PATH .'include/dblayer/functions_'.$conf['dblayer'].'.inc.php
 if(isset($conf['show_php_errors']) && !empty($conf['show_php_errors']))
 {
   @ini_set('error_reporting', $conf['show_php_errors']);
-  @ini_set('display_errors', true);
+  if($conf['show_php_errors_on_frontend'])
+  {
+    @ini_set('display_errors', true);
+  }
 }
 
 if ($conf['session_gc_probability'] > 0)

--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -487,6 +487,13 @@ $conf['template_combine_files'] = true;
 // gives an empty value '' to deactivate
 $conf['show_php_errors'] = E_ALL;
 
+// This sets the display_errors php option to true, so php errors and warning
+// messages are shown in the browser. If this is false, the error messages are 
+// available in the php log of the server if show_php_errors has any set.
+// If the below is turned off in local config and errors are still shown on 
+// frontend, check for display_errors setting server's php config
+$conf['show_php_errors_on_frontend'] = true;
+
 
 // +-----------------------------------------------------------------------+
 // |                            authentication                             |


### PR DESCRIPTION
This option can be used if we want the php errors/warnings in the server logs but not on the browser