### PR TITLE
Include PHPMailer Exception in pwg_mail()

### DIFF
--- a/include/functions_mail.inc.php
+++ b/include/functions_mail.inc.php
@@ -606,6 +606,7 @@ function pwg_mail($to, $args=array(), $tpl=array())
     $conf_mail = get_mail_configuration();
   }
 
+  include_once(PHPWG_ROOT_PATH.'include/phpmailer/Exception.php');
   include_once(PHPWG_ROOT_PATH.'include/phpmailer/SMTP.php');
   include_once(PHPWG_ROOT_PATH.'include/phpmailer/PHPMailer.php');
 


### PR DESCRIPTION
Otherwise if an exception is to be thrown it results in
Fatal error: Uncaught Error: Class 'PHPMailer\PHPMailer\Exception' not found
See https://piwigo.org/forum/viewtopic.php?id=31942
