### PR TITLE
use HTTP_X_FORWARDED_PROTO when behind a proxy

### DIFF
--- a/include/functions_url.inc.php
+++ b/include/functions_url.inc.php
@@ -37,8 +37,11 @@ function get_absolute_root_url($with_scheme=true)
   if ($with_scheme)
   {
     $is_https = false;
-    if (isset($_SERVER['HTTPS']) &&
-      ((strtolower($_SERVER['HTTPS']) == 'on') or ($_SERVER['HTTPS'] == 1)))
+    if ((isset($_SERVER['HTTPS']) &&
+        ((strtolower($_SERVER['HTTPS']) == 'on') or ($_SERVER['HTTPS'] == 1)))
+        ||
+        ((isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+         strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')))
     {
       $is_https = true;
       $url .= 'https://';


### PR DESCRIPTION
When behind a proxy, absolute root url is construct using HTTP_X_FORWARDED_HOST but is ignoring the scheme.

The modification proposed is to use HTTP_X_FORWARDED_PROTO which include the scheme when construct the absolute root url.

Use case : 
Piwigo is running in docker container which expose the service with HTTP. A traefik proxy is exposing the service via HTTPs. Without this modification, url are return with http:// scheme.

May resolve issue  #1527