### PR TITLE
Added a preliminary command line administration tool

### DIFF
--- a/admin/include/functions_install.inc.php
+++ b/admin/include/functions_install.inc.php
@@ -21,6 +21,7 @@
  * @param string $replaced
  * @param string $replacing
  */
+
 function execute_sqlfile($filepath, $replaced, $replacing, $dblayer)
 {
   $sql_lines = file($filepath);
@@ -91,23 +92,112 @@ function activate_core_plugins()
 }
 
 /**
- * Connect to database during installation. Uses $_POST.
+ * Connect to database during installation.
  *
- * @param array &$infos - populated with infos
  * @param array &$errors - populated with errors
  */
-function install_db_connect(&$infos, &$errors)
+function install_db_connect($dbhost, $dbuser, $dbpasswd, $dbname, &$errors)
 {
   try
   {
-    pwg_db_connect($_POST['dbhost'], $_POST['dbuser'],
-                   $_POST['dbpasswd'], $_POST['dbname']);
+    pwg_db_connect($dbhost, $dbuser, $dbpasswd, $dbname);
     pwg_db_check_version();
   }
   catch (Exception $e)
   {
     $errors[] = l10n($e->getMessage());
   }
+}
+
+/**
+ * Create and initialize database
+ *
+ * @param object languages - languages informations
+ * @param string language - default language
+ * @param string prefixeTable - prefix of database names
+ */
+function initialize_db($languages, $language, $prefixeTable)
+{
+  include_once(PHPWG_ROOT_PATH.PWG_LOCAL_DIR .'config/database.inc.php');
+  // tables creation, based on piwigo_structure.sql
+  execute_sqlfile(
+    PHPWG_ROOT_PATH.'install/piwigo_structure-mysql.sql',
+    DEFAULT_PREFIX_TABLE,
+    $prefixeTable,
+    'mysql'
+    );
+  // We fill the tables with basic informations
+  execute_sqlfile(
+    PHPWG_ROOT_PATH.'install/config.sql',
+    DEFAULT_PREFIX_TABLE,
+    $prefixeTable,
+    'mysql'
+    );
+
+  $query = '
+INSERT INTO '.$prefixeTable.'config (param,value,comment)
+ VALUES (\'secret_key\',md5('.pwg_db_cast_to_text(DB_RANDOM_FUNCTION.'()').'),
+ \'a secret key specific to the gallery for internal use\');';
+  pwg_query($query);
+
+  conf_update_param('piwigo_db_version', get_branch_from_version(PHPWG_VERSION));
+  conf_update_param('gallery_title', pwg_db_real_escape_string(l10n('Just another Piwigo gallery')));
+
+  conf_update_param(
+    'page_banner',
+    '<h1>%gallery_title%</h1>'."\n\n<p>".pwg_db_real_escape_string(l10n('Welcome to my photo gallery')).'</p>'
+    );
+
+  // fill languages table, only activate the current language
+  $languages->perform_action('activate', $language);
+
+  // fill $conf global array
+  load_conf_from_db();
+
+  // PWG_CHARSET is required for building the fs_themes array in the
+  // themes class
+  if (!defined('PWG_CHARSET'))
+  {
+    define('PWG_CHARSET', 'utf-8');
+  }
+  activate_core_themes();
+  activate_core_plugins();
+
+  $insert = array(
+    'id' => 1,
+    'galleries_url' => PHPWG_ROOT_PATH.'galleries/',
+    );
+  mass_inserts(SITES_TABLE, array_keys($insert), array($insert));
+
+}
+
+/**
+ * Add first admin in database
+ *
+ * @param string admin_name - admin name
+ * @param string admin_pass1 - admin password
+ * @param string admin_main - admin email
+ * @param string admin_language - language of admin
+ */
+function add_admin($admin_name, $admin_pass1, $admin_mail, $language)
+{
+  // webmaster admin user
+  $inserts = array(
+    array(
+      'id'           => 1,
+      'username'     => $admin_name,
+      'password'     => md5($admin_pass1),
+      'mail_address' => $admin_mail,
+      ),
+    array(
+      'id'           => 2,
+      'username'     => 'guest',
+      ),
+    );
+  mass_inserts(USERS_TABLE, array_keys($inserts[0]), $inserts);
+
+  create_user_infos(array(1,2), array('language' => $language));
+
 }
 
 ?>

--- a/admin/include/functions_upgrade.php
+++ b/admin/include/functions_upgrade.php
@@ -319,4 +319,30 @@ function upgrade_db_connect()
     my_error(l10n($e->getMessage()), true); 
   }
 }
+
+/**
+ * Mark all upgrades as done.
+ * Available upgrades must be ignored after a fresh installation. To
+ * make PWG avoid upgrading, we must tell it upgrades have already been
+ * made.
+ */
+function mark_all_upgrades_as_done() {
+  list($dbnow) = pwg_db_fetch_row(pwg_query('SELECT NOW();'));
+  define('CURRENT_DATE', $dbnow);
+  $datas = array();
+  foreach (get_available_upgrade_ids() as $upgrade_id)
+  {
+    $datas[] = array(
+      'id'          => $upgrade_id,
+      'applied'     => CURRENT_DATE,
+      'description' => 'upgrade included in installation',
+      );
+  }
+  mass_inserts(
+    UPGRADE_TABLE,
+    array_keys($datas[0]),
+    $datas
+  );
+}
+
 ?>

--- a/piwigo_cli.php
+++ b/piwigo_cli.php
@@ -1,0 +1,81 @@
+#!/usr/bin/php
+<?php
+
+define('PHPWG_ROOT_PATH', dirname($argv[0]) . '/');
+include(PHPWG_ROOT_PATH . 'include/config_default.inc.php');
+@include(PHPWG_ROOT_PATH. 'local/config/config.inc.php');
+defined('PWG_LOCAL_DIR') or define('PWG_LOCAL_DIR', 'local/');
+define('DEFAULT_PREFIX_TABLE', 'piwigo_');
+include(PHPWG_ROOT_PATH.PWG_LOCAL_DIR .'config/database.inc.php');
+include(PHPWG_ROOT_PATH . 'include/dblayer/functions_'.$conf['dblayer'].'.inc.php');
+include(PHPWG_ROOT_PATH . 'include/functions.inc.php');
+include(PHPWG_ROOT_PATH . 'admin/include/functions_install.inc.php');
+include(PHPWG_ROOT_PATH . 'admin/include/functions_upgrade.php');
+include(PHPWG_ROOT_PATH . 'include/constants.php');
+
+// all namespaces with options
+$namespaces_data = array('db:install' => array('language:'),
+                         'user:admin:create' => array('admin_name:', 'admin_pass:', 'admin_mail:', 'language:'),
+);
+
+// command line must starts with -c namespace
+$namespaces = array_keys($namespaces_data);
+if ($argc < 3 || $argv[1] != '-c' || !in_array($argv[2], $namespaces)) {
+  $namespaces_str = implode('|', $namespaces);
+  exit("Usage: $argv[0]: -c [$namespaces_str]" . PHP_EOL);
+}
+
+// load extra parameter for this namespace
+$namespace = $argv[2];
+$options = getopt('c:', $namespaces_data[$namespace]);
+
+// verify if all parameters are set
+$error = false;
+$namespace_options = '';
+foreach ($namespaces_data[$namespace] as $parameter) {
+  if(str_ends_with($parameter, ':')) {
+    $parameter = substr($parameter, 0, -1);
+    $namespace_options .= " --$parameter <$parameter>";
+  } else {
+    $namespace_options .= " --$parameter";
+  }
+  if (!isset($options[$parameter])) {
+    $error = true;
+  }
+}
+if ($error) {
+  exit("Some arguments are missing.". PHP_EOL . "Usage: $argv[0]: -c $namespace$namespace_options" . PHP_EOL);
+}
+
+function get_all_languages()
+{
+  include(PHPWG_ROOT_PATH . 'admin/include/languages.class.php');
+  return new languages('utf-8');
+}
+
+function validate_language($language, $languages) {
+  $languages_available = array_keys($languages->fs_languages);
+  if (!in_array($language, $languages_available))
+  {
+    exit("Invalid language $language (not in " . implode(', ', $languages_available) . ") ". PHP_EOL . "Usage: $argv[0]: -c $namespace$namespace_options" . PHP_EOL);
+  }
+}
+
+$errors = array();
+install_db_connect($conf['db_host'], $conf['db_user'], $conf['db_password'], $conf['db_base'], $errors);
+if ($namespace == 'db:install') {
+  $language = $options['language'];
+  $languages = get_all_languages();
+  validate_language($language, $languages);
+  initialize_db($languages, $language, $prefixeTable);
+  mark_all_upgrades_as_done();
+}
+else if ($namespace == 'user:admin:create')
+{
+  $language = $options['language'];
+  $languages = get_all_languages();
+  validate_language($language, $languages);
+  add_admin($options['admin_name'], $options['admin_pass'], $options['admin_mail'], $options['language']);
+}
+
+?>


### PR DESCRIPTION
It is difficult to automate installation of Piwigo.
The database initalisation and admin creation are in install.php file. Without any function.

I propose to add a command line tool to easily configure piwigo without using the browser.

This command line can initialize db:
`php piwigo_cli.php -c db:install --language fr_FR`

And create the first admin:
`php piwigo_cli.php -c user:admin:create --admin_name root --admin_pass root --admin_mail gnunux@silique.fr --language fr_FR`

Other functions may be added later.