### PR TITLE
Show the current version on the Updates page.

### DIFF
--- a/admin/themes/default/template/updates_pwg.tpl
+++ b/admin/themes/default/template/updates_pwg.tpl
@@ -167,3 +167,5 @@ p.release .errors {margin:0}
 <p><input type="hidden" name="upgrade_to" value="{$UPGRADE_TO}"></p>
 </form>
 {/if}
+
+{'Currently running version %s.'|translate:PHPWG_VERSION}

--- a/language/nl_NL/admin.lang.php
+++ b/language/nl_NL/admin.lang.php
@@ -723,7 +723,8 @@ $lang['You can\'t define a default photo order because you have a custom setting
 $lang['You have specified <i>$conf[\'order_by\']</i> in your local configuration file, this parameter in deprecated, please remove it or rename it into <i>$conf[\'order_by_custom\']</i> !'] = 'Je hebt <i>$conf[\'order_by\']</i> in je lokale configuratie-bestand gespecificeerd. Deze parameter is verouderd, verwijder hem of hernoem hem naar <i>$conf[\'order_by_custom\']</i> !';
 $lang['Following themes may not be compatible with the new version of Piwigo:'] = 'De volgende thema\'s zijn mogelijk niet compatibel met de nieuwe versie van Piwigo:';
 $lang['I decide to update anyway'] = 'Ik besluit om in ieder geval te updaten';
-$lang['Update to Piwigo %s'] = 'Update naar Piwigo%s';
+$lang['Update to Piwigo %s'] = 'Update naar Piwigo %s';
+$lang['Currently running version %s.'] = 'De huidige versie is %s.';
 $lang['Two updates are available'] = 'Twee updates zijn beschikbaar';
 $lang['This is a minor update, with only bug corrections.'] = 'Dit is een kleine update, met alleen wat gerepareerde foutjes';
 $lang['This is a major update, with <a href="%s">new exciting features</a>.'] = 'Dit is een grote update, met <a href="%s">allerlei nieuwe mogelijkheden</a>.';


### PR DESCRIPTION
After receiving an update notification I was looking for the current version number.
However I did not find that on the updates page.  This patch adds it to the bottom of that page.
It also fixes a missing space in the Dutch translation.

![image](https://user-images.githubusercontent.com/104120/177000686-8ee58bc5-b743-49c1-8231-ccbf6a25e3cf.png)
