### PR TITLE
Include PHPMailer Exception class on SMTP error

### DIFF
--- a/include/functions_mail.inc.php
+++ b/include/functions_mail.inc.php
@@ -606,6 +606,7 @@ function pwg_mail($to, $args=array(), $tpl=array())
     $conf_mail = get_mail_configuration();
   }
 
+  include_once(PHPWG_ROOT_PATH.'include/phpmailer/Exception.php');
   include_once(PHPWG_ROOT_PATH.'include/phpmailer/SMTP.php');
   include_once(PHPWG_ROOT_PATH.'include/phpmailer/PHPMailer.php');
 


### PR DESCRIPTION
As it currently stands, any issue sending mail over SMTP using PHPMailer causes a PHP exception: "Uncaught Error: Class 'PHPMailer\PHPMailer\Exception' not found". This commit includes the PHPMailer\Exception class to prevent this issue and also provide useful connection information to the Piwigo admin.