### PR TITLE
PHP 8.1 deprecation: don't pass null to file_get_contents()

### DIFF
--- a/admin/include/plugins.class.php
+++ b/admin/include/plugins.class.php
@@ -291,7 +291,7 @@ DELETE FROM '. PLUGINS_TABLE .'
           'author'=>'',
           'hasSettings'=>false,
         );
-      $plg_data = file_get_contents($path.'/main.inc.php', null, null, 0, 2048);
+      $plg_data = file_get_contents($path.'/main.inc.php', false, null, 0, 2048);
 
       if (preg_match("|Plugin Name:\\s*(.+)|", $plg_data, $val))
       {


### PR DESCRIPTION
This fixes the following PHP 8.1 deprecation notice:

> file_get_contents(): Passing null to parameter #2
> ($use_include_path) of type bool is deprecated in
> piwigo/admin/include/plugins.class.php on line 294