### PR TITLE
qsearch_results should change the ids of the result set, otherwise th…

### DIFF
--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -1428,9 +1428,9 @@ function get_quick_search_results_no_cache($q, $options)
   $search_results['qs']['matching_tags'] = $qsr->all_tags;
   $search_results['qs']['matching_cats'] = $qsr->all_cats;
   $search_results = trigger_change('qsearch_results', $search_results, $expression, $qsr);
-  if(isset($search_results['items']))
+  if (isset($search_results['items']))
   {
-    $ids=array_merge($ids,$search_results['items']);
+    $ids = array_merge($ids, $search_results['items']);
   }
   
   global $template;

--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -1427,7 +1427,7 @@ function get_quick_search_results_no_cache($q, $options)
 
   $search_results['qs']['matching_tags'] = $qsr->all_tags;
   $search_results['qs']['matching_cats'] = $qsr->all_cats;
-  $search_results = trigger_change('qsearch_results', $search_results, $expression, $qsr);
+  $ids = trigger_change('qsearch_results', $ids, $expression, $qsr);
 
   global $template;
 

--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -1427,8 +1427,12 @@ function get_quick_search_results_no_cache($q, $options)
 
   $search_results['qs']['matching_tags'] = $qsr->all_tags;
   $search_results['qs']['matching_cats'] = $qsr->all_cats;
-  $ids = trigger_change('qsearch_results', $ids, $expression, $qsr);
-
+  $search_results = trigger_change('qsearch_results', $search_results, $expression, $qsr);
+  if(isset($search_results['items']))
+  {
+    $ids=array_merge($ids,$search_results['items']);
+  }
+  
   global $template;
 
   if (empty($ids))


### PR DESCRIPTION
…e changed_results will be overwritten by the following code during permission checks fixes #1686 