### PR TITLE
Correct use_iptc_mapping, image author is '2#080' not '2#122'

### DIFF
--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -339,8 +339,10 @@ $conf['use_iptc'] = false;
 // associates a piwigo_images column name to a IPTC key
 $conf['use_iptc_mapping'] = array(
   'keywords'        => '2#025',
-  'date_creation'   => '2#055',
-  'author'          => '2#122',
+  // iptc_Date_Created 2#055 is _only_ date without time and would override
+  // EXIF DateTime, so use only if your images don't have EXIF DateTime.
+//'date_creation'   => '2#055',
+  'author'          => '2#080', // Not 2#122, which would be author of description/comment.
   'name'            => '2#005',
   'comment'         => '2#120'
   );


### PR DESCRIPTION
Also comment out date_creation iptc_Date_Created 2#055 mapping as
it overrides EXIF DateTime with _only_ date, IPTC has an extra
field iptc_Time_Created 2#060 and both would have to be combined.

See https://piwigo.org/forum/viewtopic.php?pid=184200#p184200 and https://piwigo.org/forum/viewtopic.php?pid=168381#p168381