### PR TITLE
Fix #1692 Remove Content-Length header on images (HTTP2 compat)

### DIFF
--- a/i.php
+++ b/i.php
@@ -349,7 +349,6 @@ function send_derivative($expires)
   {
     header('Expires: '.gmdate('D, d M Y H:i:s', $expires).' GMT');
   }
-  header('Content-length: '.$fstat['size']);
   header('Connection: close');
 
   $ctype="application/octet-stream";


### PR DESCRIPTION
Content-Length header should be the body size after compression (if enabled) and not the size of the original body. In HTTP1.1 such invalid value is not problematic but in HTTP2 it prevents images to display.

**WARNING** : this must be tested on a HTTP1.1 server before shipping