### PR TITLE
Update Logger.class.php to fix bug #1715

### DIFF
--- a/include/Logger.class.php
+++ b/include/Logger.class.php
@@ -364,7 +364,7 @@ class Logger
   {
     $originalTime = microtime(true);
     $micro = sprintf('%06d', ($originalTime - floor($originalTime)) * 1000000);
-    $date = new DateTime(date('Y-m-d H:i:s.'.$micro, $originalTime));
+    $date = new DateTime(date('Y-m-d H:i:s.'.$micro, intval($originalTime)));
     return $date->format($this->options['dateFormat']);
   }
 


### PR DESCRIPTION
13.0.0RC3 plugin updates fail with "Implicit conversion from float to int loses precision".  This fixes the issue (like 367 - simply forces $originalTime to an integer).