### PR TITLE
Move sending headers before the flush, fixes #1746

### DIFF
--- a/action.php
+++ b/action.php
@@ -216,17 +216,17 @@ if (ini_get('safe_mode') == 0)
   @set_time_limit(0);
 }
 
+foreach ($http_headers as $header)
+{
+  header( $header );
+}
+
 // Without clean and flush there may be some image download problems, or image can be corrupted after download
 if (ob_get_length() !== FALSE)
 {
   ob_flush();
 }
 flush();
-
-foreach ($http_headers as $header)
-{
-  header( $header );
-}
 
 @readfile($file);
 

--- a/action.php
+++ b/action.php
@@ -210,15 +210,15 @@ else
             .basename($file).'";';
 }
 
+foreach ($http_headers as $header)
+{
+  header( $header );
+}
+
 // Looking at the safe_mode configuration for execution time
 if (ini_get('safe_mode') == 0)
 {
   @set_time_limit(0);
-}
-
-foreach ($http_headers as $header)
-{
-  header( $header );
 }
 
 // Without clean and flush there may be some image download problems, or image can be corrupted after download


### PR DESCRIPTION
There was
Warning: Cannot modify header information - headers already sent in action.php on line 228 see https://piwigo.org/forum/viewtopic.php?id=32254

Unclear how headers could had been sent before sending headers, but..