### PR TITLE
Check function_exists('mime_content_type') before calling

### DIFF
--- a/admin/include/functions_metadata.php
+++ b/admin/include/functions_metadata.php
@@ -182,7 +182,7 @@ function get_sync_metadata($infos)
     $file = original_to_representative($file, $infos['representative_ext']);
   }
 
-  if (in_array(mime_content_type($file), array('image/svg+xml', 'image/svg')))
+  if (function_exists('mime_content_type') && in_array(mime_content_type($file), array('image/svg+xml', 'image/svg')))
   {
     $xml = file_get_contents($file);
 


### PR DESCRIPTION
mime_content_type() is in the fileinfo extension that may not be
installed or configured. It's also checked in action.php

See https://piwigo.org/forum/viewtopic.php?id=32327
