### PR TITLE
Fix total_count value for api function pwg.categories.getImages

### DIFF
--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -94,6 +94,8 @@ SELECT SQL_CALC_FOUND_ROWS i.*
 ;';
     $result = pwg_query($query);
 
+    list($total_images) = pwg_db_fetch_row(pwg_query('SELECT FOUND_ROWS()'));
+
     while ($row = pwg_db_fetch_assoc($result))
     {
       $image_ids[] = $row['id'];
@@ -189,15 +191,13 @@ SELECT
     }
   }
 
-  list($total_images) = pwg_db_fetch_row(pwg_query('SELECT FOUND_ROWS()'));
-
   return array(
     'paging' => new PwgNamedStruct(
       array(
         'page' => $params['page'],
         'per_page' => $params['per_page'],
         'count' => count($images),
-        'total_count' => $total_images
+        'total_count' => (int) $total_images
         )
       ),
     'images' => new PwgNamedArray(


### PR DESCRIPTION
It seems to be a regression of Piwigo 13, the total_count value in ws_categories_getImages is wrong because it's not retrieving count for the right query

Since V13 some queries have been added in this function and the pwg_db_fetch_row ends up in the wrong place

Added a cast to int to prevent having a string value in api result