### PR TITLE
Rename cat_move to albums and check for existence

### DIFF
--- a/admin/themes/default/js/albums.js
+++ b/admin/themes/default/js/albums.js
@@ -13,8 +13,10 @@ $(document).ready(() => {
     onCanSelectNode: function(node) {return false}
   });
 
-  var url_split = window.location.href.split("cat_move");
-  var catToOpen = url_split[url_split.length-1].split("-")[1];
+  var url_split = window.location.href.split("albums");
+  if(url_split.length>1) {
+    var catToOpen = url_split[url_split.length-1].split("-")[1];
+  }
 
   if(catToOpen && isNumeric(catToOpen)) {
     nodeToGo = $('.tree').tree('getNodeById', catToOpen);


### PR DESCRIPTION
Rename cat_move to albums (related to commit [425467e15f4510aca3e271c256ce7946adc6258c](https://github.com/Piwigo/Piwigo/commit/425467e15f4510aca3e271c256ce7946adc6258c))

Check if search string of split exists, because if it is not part of the string, the next step will use the whole url. Then you get a JS error 'node not found' for some domains with numbers in it (like www.example-01.org)