### PR TITLE
Introduce $conf['picture_page_banner'] to hide page banner on picture page

### DIFF
--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -287,6 +287,10 @@ $conf['linked_album_search_limit'] = 100;
 // 0 to disable.
 $conf['fs_quick_check_period'] = 24*60*60;
 
+// Show the page banner (Admin -> Configuration -> Options, tab General, Page banner)
+// on picture pages.
+$conf['picture_page_banner'] = true;
+
 // +-----------------------------------------------------------------------+
 // |                                 email                                 |
 // +-----------------------------------------------------------------------+

--- a/picture.php
+++ b/picture.php
@@ -1029,6 +1029,10 @@ if ($conf['picture_menu'] AND (!isset($themeconf['hide_menu_on']) OR !in_array('
   include( PHPWG_ROOT_PATH.'include/menubar.inc.php');
 }
 
+if (isset($conf['picture_page_banner']) && !$conf['picture_page_banner'])
+{
+  $page['page_banner'] = '';
+}
 include(PHPWG_ROOT_PATH.'include/page_header.php');
 trigger_notify('loc_end_picture');
 flush_page_messages();


### PR DESCRIPTION
The configurable page banner can take quite some precious space
from individual picture pages and may not be wanted there.
$conf['picture_page_banner'] = false;
in local config can disable it.
