### PR TITLE
issue #1951 only write to the file if it could be successfully opened

### DIFF
--- a/install.php
+++ b/install.php
@@ -330,9 +330,10 @@ define(\'DB_COLLATE\', \'\');
           'config_file_content' => $file_content,
           )
         );
+    } else {
+      @fputs($fp, $file_content, strlen($file_content));
+      @fclose($fp);
     }
-    @fputs($fp, $file_content, strlen($file_content));
-    @fclose($fp);
 
     // tables creation, based on piwigo_structure.sql
     execute_sqlfile(


### PR DESCRIPTION
Fix #1951 

Resolves the issue during the installation process to not quit with a fatal error, if the config file 'database.inc.php' could not be opened for writing.
