### PR TITLE
Fix warning in pwg.categories.php

### DIFF
--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -22,6 +22,7 @@ function ws_categories_getImages($params, &$service)
 
   $images = array();
   $image_ids = array();
+  $total_images = 0;
 
   //------------------------------------------------- get the related categories
   $where_clauses = array();


### PR DESCRIPTION
When calling "pwg.categories.getImages" with a unknow "cat_id" there is PHP notice because the $total_images variable is not defined.

Example : https://galerie.strangeplanet.fr/ws.php?format=json&method=pwg.categories.getImages&cat_id=2

This is a quick fix, perhaps the endpoint should fail when the category does not exist ?