### PR TITLE
Fix possible SQL injection in tag_name

### DIFF
--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -1720,7 +1720,7 @@ function tag_id_from_tag_name($tag_name)
   $query = '
 SELECT id
   FROM '.TAGS_TABLE.'
-  WHERE name = \''.$tag_name.'\'
+  WHERE name = \''.pwg_db_real_escape_string($tag_name).'\'
 ;';
   if (count($existing_tags = query2array($query, null, 'id')) == 0)
   {


### PR DESCRIPTION
There's a possible SQL injection issue in Piwigo Openstreetmap, s. Piwigo/piwigo-openstreetmap#163. While this PR provides a fix for the issue, I'm not sure if 1. `pwg_db_real_escape_string()` should also be added to the remaining queries in `tag_id_from_tag_name()`, and 2. if this is the correct approach at all (I would go with prepared statements, but they do not seem to be used in this project).

Fixes #2015.