### PR TITLE
fixes #2067, #656 add available sizes to sidebar

### DIFF
--- a/admin/configuration.php
+++ b/admin/configuration.php
@@ -110,6 +110,7 @@ $display_info_checkboxes = array(
     'visits',
     'rating_score',
     'privacy_level',
+    'available_sizes',
   );
 
 // image order management

--- a/admin/themes/default/template/configuration_display.tpl
+++ b/admin/themes/default/template/configuration_display.tpl
@@ -320,6 +320,14 @@
           {'Who can see this photo?'|translate} <span class="adminOnlyIcon tiptip" title="{'available for administrators only'|translate}"><i class="icon-users"></i> {'administrators'}</span>
         </label>
       </li>
+
+      <li>
+        <label class="font-checkbox">
+          <span class="icon-check"></span>
+          <input type="checkbox" name="picture_informations[available_sizes]" {if ($display.picture_informations.available_sizes)}checked="checked"{/if}>
+          {'Show available sizes?'|translate}
+        </label>
+      </li>
     </ul>
   </fieldset>
 

--- a/themes/default/template/picture.tpl
+++ b/themes/default/template/picture.tpl
@@ -30,6 +30,8 @@ function changeImgSrc(url,typeSave,typeMap)
 		theImg.src = url;
 		theImg.useMap = "#map"+typeMap;
 	}
+	jQuery('#derivativeSwitchList .switchCheck').css('visibility','hidden');
+	jQuery('#derivativeListChecked'+typeMap).css('visibility','visible');
 	jQuery('#derivativeSwitchBox .switchCheck').css('visibility','hidden');
 	jQuery('#derivativeChecked'+typeMap).css('visibility','visible');
 	document.cookie = 'picture_deriv='+typeSave+';path={/literal}{$COOKIE_PATH}{literal}';
@@ -321,6 +323,26 @@ function setPrivacyLevel(id, level){
 				{/foreach}
 			</div>
 		</dd>
+	</div>
+{/if}
+
+{if $display_info.available_sizes and !empty($current.unique_derivatives)}
+	{footer_script require='jquery'}{literal}
+	{/literal}{/footer_script}
+	<div id="derivativeSwitchList" class="imageInfo">
+		<dt>Available Sizes</dt>
+		{foreach from=$current.unique_derivatives item=derivative key=derivative_type}
+			<dd>
+				<span class="switchCheck" id="derivativeListChecked{$derivative->get_type()}"
+					{if $derivative->get_type() ne $current.selected_derivative->get_type()}
+					style="visibility:hidden" {/if}>&#x2714; </span>
+				<a
+					href="javascript:changeImgSrc('{$derivative->get_url()|@escape:javascript}','{$derivative_type}','{$derivative->get_type()}')">
+					{$derivative->get_type()|@translate}<span class="derivativeSizeDetails">
+						({$derivative->get_size_hr()})</span>
+				</a>
+			</dd>
+		{/foreach}
 	</div>
 {/if}
 {/strip}

--- a/themes/default/template/picture.tpl
+++ b/themes/default/template/picture.tpl
@@ -343,6 +343,9 @@ function setPrivacyLevel(id, level){
 				</a>
 			</dd>
 		{/foreach}
+		{if isset($U_ORIGINAL)}
+		  <dd><a href="javascript:phpWGOpenWindow('{$U_ORIGINAL}','xxx','scrollbars=yes,toolbar=no,status=no,resizable=yes')" rel="nofollow">{'Original'|@translate}</a></dd>
+		{/if}
 	</div>
 {/if}
 {/strip}


### PR DESCRIPTION
in reference to #2067 & #656 

adds configuration checkbox to admin display settings
when checked and derivatives available, size options are shown.
changing the size using the upper menu icon or in the info list updates both lists check marks.

Result follows code and style conventions:
![image](https://github.com/Piwigo/Piwigo/assets/17554977/17ab2420-6a78-41bc-bf9b-653059688054)

(i don't know how to seed the setting so that it doesn't throw an error prior to first submission, so if you show me how, i'd be happy to ammend the pr.)