### PR TITLE
Fix missing EXIF metadata for images uploaded in HEIC format

### DIFF
--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -602,7 +602,7 @@ function upload_file_heic($representative_ext, $file_path)
   list($w,$h) = get_optimal_dimensions_for_representative();
 
   $exec = $conf['ext_imagick_dir'].'convert';
-  $exec.= ' -sampling-factor 4:2:0 -quality 85 -interlace JPEG -colorspace sRGB -auto-orient +repage -strip -resize "'.$w.'x'.$h.'>"';
+  $exec.= ' -sampling-factor 4:2:0 -quality 85 -interlace JPEG -colorspace sRGB -auto-orient +repage -resize "'.$w.'x'.$h.'>"';
   $exec.= ' "'.realpath($file_path).'"';
   $exec.= ' "'.$representative_file_path.'"';
   $exec.= ' 2>&1';


### PR DESCRIPTION
The representative jpg file produced for image uploaded in HEIC format is used later to obtain EXIF metadata. Hence don't "strip" HEIC file metadata when corresponding representative is prepared.