### PR TITLE
Fix quicksearching by category name with spaces

### DIFF
--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -1367,7 +1367,7 @@ SELECT
       && (($expr->stoken_modifiers[$i] & (QST_QUOTED|QST_WILDCARD)) == 0)
       && (($expr->stoken_modifiers[$i+1] & (QST_BREAK|QST_QUOTED|QST_WILDCARD)) == 0) )
     {
-      $common = array_intersect( $token_cat_ids[$i], $token_cat_ids[$i+1] );
+      $common = array_values(array_intersect( $token_cat_ids[$i], $token_cat_ids[$i+1] ));
       if (count($common))
       {
         $token_cat_ids[$i] = $token_cat_ids[$i+1] = $common;


### PR DESCRIPTION
Because `get_subcat_ids` expects the passed-in array to be contiguous, failing to call `array_values` after `array_intersect` sometimes leads to errors, when one has a search query like `category:Foo Bar` and there exists both categories `Foo Bar` and `Foo Baz`.