### PR TITLE
Fix for #2114: Check for photos missing md5sum before trying to update md5sums

### DIFF
--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -2593,8 +2593,14 @@ function ws_images_setMd5sum($params, $service)
 
   include_once(PHPWG_ROOT_PATH.'admin/include/functions.php');
 
-  $md5sum_ids_to_add = array_slice(get_photos_no_md5sum(), 0, $params['block_size']);
-  $added_count = add_md5sum($md5sum_ids_to_add);
+  $nb_no_md5sum = count(get_photos_no_md5sum());
+  $added_count = 0;
+
+  if ($nb_no_md5sum > 0)
+  {
+    $md5sum_ids_to_add = array_slice(get_photos_no_md5sum(), 0, $params['block_size']);
+    $added_count = add_md5sum($md5sum_ids_to_add);
+  }
 
   return array(
     'nb_added' => $added_count,


### PR DESCRIPTION
Fix for https://github.com/Piwigo/Piwigo/issues/2114; same approach as used in the admin UI:

https://github.com/Piwigo/Piwigo/blob/562170528c63a2318d153a08ec4847684fa71784/admin.php#L290-L295