### PR TITLE
FIX avoid redirection loop after auth behind reverse proxy

### DIFF
--- a/include/functions_session.inc.php
+++ b/include/functions_session.inc.php
@@ -105,12 +105,18 @@ function get_remote_addr_session_hash()
   {
     return '';
   }
-  
-  if (strpos($_SERVER['REMOTE_ADDR'],':')===false)
+
+  $remoteAddr = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
+
+  if (strpos($remoteAddr,':')===false)
   {//ipv4
+    if(strpos($remoteAddr, ',') !== false)
+    {
+      $remoteAddr = strstr($remoteAddr, ",", true);
+    }
     return vsprintf(
       "%02X%02X",
-      explode('.',$_SERVER['REMOTE_ADDR'])
+      explode('.',$remoteAddr)
     );
   }
   return ''; //ipv6 not yet


### PR DESCRIPTION
Hi,

When my Piwigo is behind a reverse proxy in k8s, after authentication, I have a loop between index and identification.

The issue comes from the use of REMOTE_ADDR to compute remote addr session hash.

So, if a header 'HTTP_X_FORWARDED_FOR' is set by a reverse proxy, we use the first element in this header instead of REMOTE_ADDR to compute the hash.

Bye.