### PR TITLE
Fix nl_NL translation

### DIFF
--- a/language/nl_NL/admin.lang.php
+++ b/language/nl_NL/admin.lang.php
@@ -819,7 +819,7 @@ $lang['Shotwell is an open source digital photo organizer that runs on Linux. It
 $lang['The file or directory cannot be accessed (either it does not exist or the access is denied)'] = 'Het bestand of de map kan niet worden geopend (of het bestaat niet of de toegang wordt geweigerd)';
 $lang['The Piwigo publish Plug-in allows you to export and synchronize photos from Lightroom directly to your Piwigo photo gallery.'] = 'Met de Piwigo Publish plug-in kun je foto\'s direct vanuit Lightroom naar jouw Piwigo fotogalerie exporteren en synchroniseren.';
 $lang['Web Form'] = 'Via webformulier';
-$lang['%u users have automatic permission because they belong to a granted group.'] = '%jouw gebruikers hebben automatisch recht, omdat ze tot een groep behoren die dit recht is verleend';
+$lang['%u users have automatic permission because they belong to a granted group.'] = '%u gebruikers hebben automatisch recht, omdat ze tot een groep behoren die dit recht is verleend';
 $lang['Aperture is a powerful tool to refine images and manage massive libraries on Mac.'] = 'Aperture is een krachtig gereedschap om grote hoeveelheden foto\'s te beheren en te verbeteren op een Mac.';
 $lang['Aperture is designed for professional photographers with iPhoto simplicity.'] = 'Aperture is gemaakt voor professionele fotografen met iPhoto gemak.';
 $lang['Apply watermark if height is bigger than'] = 'Breng watermerk aan als de hoogte groter is dan';


### PR DESCRIPTION
Some-one|thing mistook the u in %u for "you" and translated the
specifier to %jouw where %j leads to
Fatal error: Uncaught ValueError: Unknown format specifier "j"

See https://piwigo.org/forum/viewtopic.php?id=33492

Already since

    commit 6011ae152d94cad2cdae3776fa5d1584ad2e7bc2 (tag: 2.9.0RC1)
    CommitDate: Fri Mar 31 15:55:26 2017 +0200

        update language directory from the "translation" branch