### PR TITLE
Correction for  PHP Deprecated:  explode()

### DIFF
--- a/admin/plugin.php
+++ b/admin/plugin.php
@@ -14,7 +14,7 @@ if( !defined("PHPWG_ROOT_PATH") )
 include_once(PHPWG_ROOT_PATH.'admin/include/functions.php');
 check_status(ACCESS_ADMINISTRATOR);
 
-$sections = explode('/', $_GET['section'] );
+$sections = explode('/', $_GET['section'] ?? '');
 for ($i=0; $i<count($sections); $i++)
 {
   if (empty($sections[$i]))


### PR DESCRIPTION
More robust syntax if $_GET['section'] turns out to be null, avoid messages as PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated