### PR TITLE
Fix "total_count" type on some WS methods

### DIFF
--- a/admin/themes/default/js/user_list.js
+++ b/admin/themes/default/js/user_list.js
@@ -2087,12 +2087,12 @@ function update_user_list() {
                 // console.log(data.message);
                 return;
             }
-            total_users = data.result.total_count;
+            total_users = data.result.paging.total_count;
             if (first_update) {
                 $("h1").append(`<span class='badge-number'>${total_users}</span>`);
                 first_update = false;
             }
-            nb_filtered_users = data.result.total_count;
+            nb_filtered_users = data.result.paging.total_count;
             update_pagination_menu();
             current_users = data.result.users;
             generate_user_list();

--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -137,6 +137,7 @@ SELECT SQL_CALC_FOUND_ROWS i.*
     }
 
     list($total_images) = pwg_db_fetch_row(pwg_query('SELECT FOUND_ROWS()'));
+    $total_images = (int)$total_images;
 
     // let's take care of adding the related albums to each photo
     if (count($image_ids) > 0)

--- a/include/ws_functions/pwg.users.php
+++ b/include/ws_functions/pwg.users.php
@@ -243,6 +243,7 @@ SELECT DISTINCT ';
   if (isset($params['display']['total_count'])) {
     $total_count_query_result = pwg_query('SELECT FOUND_ROWS();');
     list($total_count) = pwg_db_fetch_row($total_count_query_result);
+    $total_count = (int)$total_count;
   }
   while ($row = pwg_db_fetch_assoc($result))
   {
@@ -351,12 +352,14 @@ SELECT DISTINCT ';
         array(
           'page' => $params['page'],
           'per_page' => $params['per_page'],
-          'count' => count($users)
+          'count' => count($users),
+          'total_count' => $total_count,
           )
         ),
       'users' => new PwgNamedArray(array_values($users), 'user')
     );
   }
+  // deprecated: kept for retrocompatibility
   if (isset($params['display']['total_count'])) {
     $method_result['total_count'] = $total_count;
   }


### PR DESCRIPTION
Working on a JS client for the WS I noticed some "total_count" field that were returned as strings.

Also the "total_count" on the ws_users_getList method was not at the same location as other paginated methods.