### PR TITLE
Fix check "activate_comments" config in WS

### DIFF
--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -301,6 +301,13 @@ function remove_chunks($original_sum, $type)
  */
 function ws_images_addComment($params, $service)
 {
+  global $conf;
+
+  if (!$conf['activate_comments'])
+  {
+    return new PwgError(403, 'Comments are disabled');
+  }
+
   $query = '
 SELECT DISTINCT image_id
   FROM '. IMAGE_CATEGORY_TABLE .'
@@ -511,7 +518,8 @@ SELECT id, date, author, content
   }
 
   $comment_post_data = null;
-  if ($is_commentable and
+  if ($conf['activate_comments'] and
+      $is_commentable and
       (!is_a_guest()
         or (is_a_guest() and $conf['comments_forall'] )
       )


### PR DESCRIPTION
I noticed that if the comments are globally disabled but a category is flagged `commentable` (might have been checked before disabling the comments).

- `ws_images_getInfo` stills generate a post token
- `ws_images_addComment` accepts the comment

I modified both methods though only the change in `ws_images_getInfo`  would be enough