### PR TITLE
Add `ws_getImages_details` and `ws_images_getInfo` triggers

### DIFF
--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -133,7 +133,7 @@ SELECT SQL_CALC_FOUND_ROWS i.*
       }
       $image = array_merge($image, ws_std_get_urls($row));
 
-      $images[] = $image;
+      $images[] = trigger_change('ws_getImages_details', $image, $row, $params);
     }
 
     list($total_images) = pwg_db_fetch_row(pwg_query('SELECT FOUND_ROWS()'));

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -575,6 +575,8 @@ SELECT id, date, author, content
     array('id','date')
     );
 
+  $ret = trigger_change('ws_images_getInfo', $ret);
+
   if ($service->_responseFormat != 'rest')
   {
     return $ret; // for backward compatibility only
@@ -693,7 +695,7 @@ SELECT *
       }
 
       $image = array_merge($image, ws_std_get_urls($row));
-      $images[ $image_ids[ $image['id'] ] ] = $image;
+      $images[ $image_ids[ $image['id'] ] ] = trigger_change('ws_getImages_details', $image, $row, $params);
     }
     ksort($images, SORT_NUMERIC);
     $images = array_values($images);

--- a/include/ws_functions/pwg.tags.php
+++ b/include/ws_functions/pwg.tags.php
@@ -188,7 +188,7 @@ SELECT *
       }
 
       $image['tags'] = new PwgNamedArray($image_tags, 'tag', ws_std_get_tag_xml_attributes() );
-      $images[] = $image;
+      $images[] = trigger_change('ws_getImages_details', $image, $row, $params);
     }
 
     usort($images, 'rank_compare');

--- a/tools/triggers_list.php
+++ b/tools/triggers_list.php
@@ -718,7 +718,7 @@ array(
   'name' => 'render_category_description',
   'type' => 'trigger_change',
   'vars' => array('string', 'category_description', 'string', 'action'),
-  'files' => array('include\category_cats.inc.php', 'include\section_init.inc.php', 'include\ws_functions.inc.php (ws_categories_getList, ws_categories_getAdminList)'),
+  'files' => array('include\category_cats.inc.php', 'include\section_init.inc.php', 'include\ws_functions\pwg.categories.php (ws_categories_getList, ws_categories_getAdminList)'),
 ),
 array(
   'name' => 'render_category_literal_description',
@@ -730,7 +730,7 @@ array(
   'name' => 'render_category_name',
   'type' => 'trigger_change',
   'vars' => array('string', 'category_name', 'string', 'location'),
-  'files' => array('admin\cat_list.php', 'include\ws_functions.inc.php (ws_categories_getList, ws_categories_getAdminList, ws_categories_move)'),
+  'files' => array('admin\cat_list.php', 'include\ws_functions\pwg.categories.php (ws_categories_getList, ws_categories_getAdminList, ws_categories_move)'),
 ),
 array(
   'name' => 'render_comment_author',
@@ -920,8 +920,26 @@ array(
   'name' => 'ws_users_getList',
   'type' => 'trigger_change',
   'vars' => array('array', 'users'),
-  'files' => array('include\ws_functions\pwg.users.php'),
+  'files' => array('include\ws_functions\pwg.users.php (ws_users_getList)'),
   'infos' => 'New in 2.6.2.',
+),
+array(
+  'name' => 'ws_images_getInfo',
+  'type' => 'trigger_change',
+  'vars' => array('object', 'image'),
+  'files' => array('include\ws_functions\pwg.images.php (ws_images_getInfo)'),
+  'infos' => 'New in 15.', 
+),
+array(
+  'name' => 'ws_getImages_details',
+  'type' => 'trigger_change',
+  'vars' => array('object', 'image', 'object', 'db_row', 'object', 'params'),
+  'files' => array(
+    'include\ws_functions\pwg.categories.php (ws_categories_getImages)',
+    'include\ws_functions\pwg.images.php (ws_images_search)',
+    'include\ws_functions\pwg.tags.php (ws_tags_getImages)',
+  ),
+  'infos' => 'New in 15. Allows to expose more fields in images lists WebServices.<br><strong>WARNING:</strong> called for each image, avoid doing expensive tasks in the handler.', 
 ),
 );
 ?>


### PR DESCRIPTION
These new triggers allow plugins to add data in images lists (from album, tag and search) and single image request.

I don't know if `ws_getImages_details` is a good name, as it is shared accross three differents methods.

