### PR TITLE
Fix error when adding custom port to mysql host

### DIFF
--- a/include/dblayer/functions_mysqli.inc.php
+++ b/include/dblayer/functions_mysqli.inc.php
@@ -45,6 +45,7 @@ function pwg_db_connect($host, $user, $password, $database)
   elseif (strpos($host, ':') !== false)
   {
     list($host, $port) = explode(':', $host);
+    $port = (int) $port;
   }
 
   $dbname = '';


### PR DESCRIPTION
Fixes the following error:

```
2024/10/01 11:07:24 [error] 298#298: *1 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: mysqli::__construct(): Argument #5 ($port) must be of type ?int, string given in /app/www/public/include/dblayer/functions_mysqli.inc.php:52
Stack trace:
#0 /app/www/public/include/dblayer/functions_mysqli.inc.php(52): mysqli->__construct()
#1 /app/www/public/admin/include/functions_install.inc.php(103): pwg_db_connect()
#2 /app/www/public/install.php(260): install_db_connect()
#3 {main}
  thrown in /app/www/public/include/dblayer/functions_mysqli.inc.php on line 52"
```