### PR TITLE
Configuration setting and code to always send email from the "mail_sender_" settings

### DIFF
--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -319,6 +319,11 @@ $conf['mail_sender_name'] = '';
 // define the email of sender mail: if value is empty, webmaster email is used
 $conf['mail_sender_email'] = '';
 
+// set true to always use mail_sender_name and mail_sender_email, if set,
+// for the From address.
+// the original From values will be used as Reply-To
+$conf['mail_always_from_mail_sender'] = false;
+
 // set true to allow text/html emails
 $conf['mail_allow_html'] = true;
 


### PR DESCRIPTION
These changes are mainly to address the problem where emails from the Contact Form plugin don't reach their destination, as described at the end of this web page:
https://doc.piwigo.org/customizing-your-gallery/add-pages-to-piwigo-gallery
in section "_Frequent problems with the Contact Form plugin_"

The issue is that the "_From_" email address is the address that was entered in the form, which doesn't pass SPF, DKIM and DMARC tests performed between the mail servers.

A new boolean configuration setting, *mail_always_from_mail_sender*, has been added. If this is left with the default _false_ value, everything behaves as it does currently.

If *mail_always_from_mail_sender* is set to _true_, then mail sent using the *pwg_mail()* function will have the "_From_" address set to what is returned by the *get_mail_sender_email()* and *get_mail_sender_name()* functions, instead of the email address that is provided to *pwg_mail()* by *$args['from']* (as the Contact Form does). The *$args['from']* address is still used for the email "_Reply-To_" field, so replies to should still be addressed to the *$args['from']* address.

Although intended towards the Contact Form issues, these changes will also apply to (and likely be useful for) any other extensions or code that uses the *pwg_mail()* function.