### PR TITLE
Support config 'exiftool_path' for path of exiftool binary

### DIFF
--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -373,6 +373,10 @@ $conf['use_iptc_mapping'] = array(
   'comment'         => '2#120'
   );
 
+// exiftool_path: Location of exiftool binary. Must be set if not within $PATH 
+// or when specific version is required. Example '\var\lib\Image\ExifTool-10.75\exiftool'
+$conf['exiftool_path'] = 'exiftool';
+
 // show_exif: Show EXIF metadata on picture.php (table or line presentation
 // available)
 $conf['show_exif'] = true;


### PR DESCRIPTION
Setting used by a few PlugIns, e.g [Piwigo-exiftool_keywords](https://github.com/plegall/Piwigo-exiftool_keywords/pull/5) and [Piwigo-write_metadata](https://github.com/plegall/Piwigo-write_metadata/blob/9e240f9cb87107138e2e5417355741d7577a0db9/main.inc.php#L145)