### PR TITLE
fix *.part data corruption

### DIFF
--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -1746,7 +1746,7 @@ function ws_images_upload($params, $service)
   // file_put_contents('/tmp/plupload.log', "[".date('c')."] ".__FUNCTION__.', '.$fileName.' '.($chunk+1).'/'.$chunks."\n", FILE_APPEND);
 
   // Open temp file
-  if (!$out = @fopen("{$filePath}.part", $chunks ? "ab" : "wb"))
+  if (!$out = @fopen("{$filePath}.part", $chunks && $chunk != 0 ? "ab" : "wb"))
   {
     die('{"jsonrpc" : "2.0", "error" : {"code": 102, "message": "Failed to open output stream."}, "id" : "id"}');
   }


### PR DESCRIPTION
Fixed a bug where when a file upload failed, re-uploading the file would cause the uploaded data to be damaged.

* [issues 1649](https://github.com/Piwigo/Piwigo/issues/1649)
* [issues 1773](https://github.com/Piwigo/Piwigo/issues/1773)

First of all, I don't know PHP, so I found a system runtime bug and modified the code to fix the problem through experience in other languages. I'm not sure if there is a better fix in PHP, but this fix code solved it Bugs I encountered.

I encountered the problem of corrupted video upload in [issues 1649](https://github.com/Piwigo/Piwigo/issues/1649). 

Re-state the problem description after analysis:
1. When uploading a file that needs to be chunked (this is very common when uploading videos)
2. If some parts are uploaded, it fails at this time (for example, network problem)
3. After the network is restored, the video is uploaded again. The video data after the upload is successful is damaged.

This bug can be reproduced 100% because there is an obvious bug in the code:
1. For files with the same hash, piwigo will create a temporary file with the same name(example a.part) to store the chunks during upload.
2. After step 2 above, part of the data has been written to a.part, but this temporary file was not deleted after step 2 failed.
3. Execute step 3 above, the web page will retransmit all chunks (including the chunks written in step 2). But at this time, the server appends the newly received chunks to a.part in the form of "ab", which directly leads to data corruption.


```
begin upload a.mp4
web client upload chunk1 chunk2 chunk3 .... chunkN -> server
server get chunk1 chunk2 to a.part then network error

web client retry upload chunk1 chunk2 chunk3 ... chunkN -> server
server append chunk1 chunk2 chunk3 ... chunkN to a.part

Finally got chunk1+chunk2+ chunk1+chunk2+chunk3+...+chunkN -> server saved a.mp4
```

