### PR TITLE
respect !$conf['meta_ref']

### DIFF
--- a/picture.php
+++ b/picture.php
@@ -606,7 +606,7 @@ $metadata_showable = trigger_change(
   $picture['current']
   );
 
-if ( $metadata_showable and pwg_get_session_var('show_metadata') )
+if ( $metadata_showable and pwg_get_session_var('show_metadata')  and !$conf['meta_ref'] )
 {
   $page['meta_robots']=array('noindex'=>1, 'nofollow'=>1);
 }


### PR DESCRIPTION
$conf['meta_ref']should be respected in html headers meta element: noindex,nofollow for robots should be configured there!