### PR TITLE
Add config option to disable split words on search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is my horrible fork of piwigo, I add the changes I make to my piwigo instance here.
+Use at your own risk.
 <img src="https://piwigo.org/plugins/piwigo-piwigodotorg/images/piwigo.org.svg" width="200" alt="Piwigo logo">
 
 Manage your photo library. Piwigo is open source photo gallery software for the web. Designed for organisations, teams and individuals.

--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -1000,6 +1000,11 @@ $conf['checksum_compute_blocksize'] = 50;
 // _data/cache directory
 $conf['quick_search_include_sub_albums'] = false;
 
+// Search split words: Split words in a search query.
+// For example, if search is "red tomatoes", then we only display photos
+// with "red tomatoes" and not "red", "tomatoes" in the fields
+$conf['search_split_words'] = true;
+
 // +-----------------------------------------------------------------------+
 // |                                 log                                   |
 // +-----------------------------------------------------------------------+

--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -2029,6 +2029,7 @@ function get_search_results($search_id, $super_order_by, $images_where='')
 
 function split_allwords($raw_allwords)
 {
+  global $conf;
   $words = null;
 
   // we specify the list of characters to trim, to add the ".". We don't want to split words
@@ -2041,16 +2042,15 @@ function split_allwords($raw_allwords)
     $drop_char_replace = array(' ',' ',' ',' ',' ',' ', '', '', ' ',' ',' ',' ',' ',' ',' ' ,' ',' ',' ',' ',' ','' , ' ',' ',' ', ' ',' ');
 
     // Split words
-    $words = array_unique(
-      preg_split(
-        '/\s+/',
-        str_replace(
-          $drop_char_match,
-          $drop_char_replace,
-          $raw_allwords
-        )
-      )
-    );
+    $processed_words = str_replace($drop_char_match, $drop_char_replace, $raw_allwords);
+    if ($conf['search_split_words']) 
+    {
+      return array_unique(preg_split('/\s+/', $processed_words));
+    } 
+    else 
+    {
+      return array($processed_words);
+    }
   }
 
   return $words;

--- a/include/functions_search.inc.php
+++ b/include/functions_search.inc.php
@@ -2029,31 +2029,38 @@ function get_search_results($search_id, $super_order_by, $images_where='')
 
 function split_allwords($raw_allwords)
 {
-  global $conf;
-  $words = null;
+    global $conf;
+    $words = null;
 
-  // we specify the list of characters to trim, to add the ".". We don't want to split words
-  // on "." but on ". ", and we have to deal with trailing dots.
-  $raw_allwords = trim($raw_allwords, " \n\r\t\v\x00.");
+    // Trim unwanted characters, including trailing dots
+    $raw_allwords = trim($raw_allwords, " \n\r\t\v\x00.");
 
-  if (!preg_match('/^\s*$/', $raw_allwords))
-  {
-    $drop_char_match   = array(';','&','(',')','<','>','`','\'','"','|',',','@','?','%','. ','[',']','{','}',':','\\','/','=','\'','!','*');
-    $drop_char_replace = array(' ',' ',' ',' ',' ',' ', '', '', ' ',' ',' ',' ',' ',' ',' ' ,' ',' ',' ',' ',' ','' , ' ',' ',' ', ' ',' ');
+    if (!preg_match('/^\s*$/', $raw_allwords)) {
+        $drop_char_match   = array(';', '&', '(', ')', '<', '>', '`', '|', ',', '@', '?', '%', '. ', '[', ']', '{', '}', ':', '\\', '/', '=', '!', '*');
+        $drop_char_replace = array(' ', ' ', ' ', ' ', ' ', ' ', '', '', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '', ' ', ' ', ' ', ' ', ' ');
 
-    // Split words
-    $processed_words = str_replace($drop_char_match, $drop_char_replace, $raw_allwords);
-    if ($conf['search_split_words']) 
-    {
-      return array_unique(preg_split('/\s+/', $processed_words));
-    } 
-    else 
-    {
-      return array($processed_words);
+        // Replace unwanted characters
+        $processed_words = str_replace($drop_char_match, $drop_char_replace, $raw_allwords);
+
+        // Remove extra spaces introduced during replacement
+        $processed_words = preg_replace('/\s+/', ' ', $processed_words);
+        $processed_words = trim($processed_words);
+
+        // Use a regular expression to split words while respecting quoted text
+        $pattern = '/"([^"]+)"|\'([^\']+)\'|(\S+)/';
+        preg_match_all($pattern, $processed_words, $matches);
+
+        // Extract matches and flatten the array
+        $result = array_merge(
+            array_filter($matches[1]), // Double-quoted phrases
+            array_filter($matches[2]), // Single-quoted phrases
+            array_filter($matches[3])  // Unquoted words
+        );
+
+        return array_unique($result);
     }
-  }
 
-  return $words;
+    return $words;
 }
 
 function get_available_search_uuid()


### PR DESCRIPTION
This config option allows to search for descriptions more easily, because spaces won't split into 2 different search terms.
The default behavior is unchanged, it only adds a new option for those who would like to disable the splitting of words.