### PR TITLE
Issue 1915 Robustify hash of user IP

### DIFF
--- a/include/functions_session.inc.php
+++ b/include/functions_session.inc.php
@@ -103,7 +103,8 @@ function get_remote_addr_session_hash()
     return '';
   }
   
-  if (strpos($_SERVER['REMOTE_ADDR'],':')===false)
+  // REMOTE_ADDR could be '/srv/mp/socket' on virtualized environment => be sure the IP contains some dot without port
+  if (strpos($_SERVER['REMOTE_ADDR'],':')===false && strpos($_SERVER['REMOTE_ADDR'],'.'))
   {//ipv4
     return vsprintf(
       "%02X%02X",


### PR DESCRIPTION
Hello,

This PR fixes #1915.

On some virtualized environment, the user IP stored in `$_SERVER['REMOTE_ADDR']` could be `/srv/mp/socket`.

In this case, `get_remote_addr_session_hash()` crashes with:
```
Fatal error: Uncaught ValueError: The arguments array must contain 2 items, 1 given in /var/www/include/functions_session.inc.php:114 Stack trace: #0 /var/www/include/functions_session.inc.php(114): vsprintf() #1 /var/www/include/functions_session.inc.php(131): get_remote_addr_session_hash() #2 [internal function]: pwg_session_read() #3 /var/www/include/common.inc.php(150): session_start() #4 /var/www/index.php(11): include_once('...') #5 {main} thrown in /var/www/include/functions_session.inc.php on line 114
```

The solution could be to robustify the IPV4 hash creation only with IP contains some dot.

Best regards