### PR TITLE
Add a more granular container detection

### DIFF
--- a/admin/maintenance_env.php
+++ b/admin/maintenance_env.php
@@ -267,7 +267,12 @@ $php_current_timestamp = date("Y-m-d H:i:s");
 $db_version = pwg_get_db_version();
 list($db_current_date) = pwg_db_fetch_row(pwg_query('SELECT now();'));
 
-list($container_name,$container_version) = getContainerInfo();
+list($container_name,$container_version) = get_container_info();
+
+if (!in_array($container_name, ['Official','none']))
+{
+  $container_name = '(unofficial) '.$container_name;
+}
 
 $template->assign(
   array(
@@ -291,7 +296,7 @@ $template->assign(
     'PWG_VERSION' => PHPWG_VERSION,
     'U_CHECK_UPGRADE' => sprintf($url_format, 'check_upgrade'),
     'OS' => PHP_OS,
-    'CONTAINER_INFO' => $container_name.($container_version != null ? ' '.$container_version : ''),
+    'CONTAINER_INFO' => $container_name.(!empty($container_version) ? ' '.$container_version : ''),
     'PHP_VERSION' => phpversion(),
     'DB_ENGINE' => 'MySQL',
     'DB_VERSION' => $db_version,

--- a/admin/themes/default/template/maintenance_env.tpl
+++ b/admin/themes/default/template/maintenance_env.tpl
@@ -18,7 +18,7 @@ const unit_MB = "{"%s MB"|@translate}"
 {/if}
     <li>{'Operating system'|@translate}: {$OS}</li>
     {if {$CONTAINER_INFO} neq 'none'}
-      <li>{'Container info'}: {$CONTAINER_INFO}</li>
+      <li>{'Container info'|translate}: {$CONTAINER_INFO}</li>
     {/if}
     <li>PHP: {$PHP_VERSION} (<a href="{$U_PHPINFO}" class="externalLink">{'Show info'|@translate}</a>)  [{$PHP_DATATIME}]</li>
     <li>{$DB_ENGINE}: {$DB_VERSION} [{$DB_DATATIME}]</li>


### PR DESCRIPTION
Replace is_in_container by getContainerInfo
Curently detect Official container (once they update a version with a tagfile) and LinuxServer container All other container are marked as Unkown

Report two field :
- container_type ( none | Official | LinuxServer | Unknown
- container_version ( build Version number like 16.2.0a, only reported if Official container is detected )