### PR TITLE
getimagesize: Wrong detection of stereoscopic file formats

### DIFF
--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -232,7 +232,10 @@ SELECT
     $file_path = $upload_dir.'/'.$filename_wo_ext.'.';
 
     list($width, $height, $type) = getimagesize($source_filepath);
-    
+
+    // adjust file type for wrongly detected extensions (jps stereo image format is detected as jpg...)
+    $type = trigger_change('update_type', $type, $original_filename);
+
     if (IMAGETYPE_PNG == $type)
     {
       $file_path.= 'png';


### PR DESCRIPTION
Avant de publier une nouvelle version compatible avec la version 16 de Piwigo, je voudrais bien résoudre le probléme suivant, concernant l'upload de fichiers stéréoscopiques de type JPS ou MPO.
L'uploader de piwigo change systématiquement l'extension jps du fichier que j'upload en jpg.
Il n'a pas tout à fait tort, jps étant un conteneur tellement mal fichu (ce n'est qu'un fichier jpeg qui contient les vues droite et gauche) que getimagesize ne fait pas la différence. C'est gênant, notamment pour la création de l'image représentative, pour la prise en compte du fait que cette image doit etre visualisée en 3D, etc
Je ne souhaite pas que piwigo prenne des initiatives de renommage que je doit gérer moi même. C'est pourquoi je propose l'introduction de ce trigger. Cela ne change en rien le fonctionnement de Piwigo si le callback n'est pas exécuté, mais permet de traiter des formats de fichiers non prévus...
Merci de votre compréhension

JP MASSARD
https://photo3d.jpmassard.fr
