### PR TITLE
issue 222 configurable char for keyword split

### DIFF
--- a/admin/include/functions_metadata.php
+++ b/admin/include/functions_metadata.php
@@ -27,7 +27,7 @@ function get_sync_iptc_data($file)
 
   $map = $conf['use_iptc_mapping'];
 
-  $iptc = get_iptc_data($file, $map);
+  $iptc = get_iptc_data($file, $map, $conf['metadata_keyword_separator_char']);
 
   foreach ($iptc as $pwg_key => $value)
   {
@@ -305,7 +305,7 @@ SELECT id, path, representative_ext
           $tags_of[$id] = array();
         }
 
-        foreach (explode(',', $data[$key]) as $tag_name)
+        foreach (explode($conf['metadata_keyword_separator_char'], $data[$key]) as $tag_name)
         {
           $tags_of[$id][] = tag_id_from_tag_name($tag_name);
         }
@@ -415,18 +415,21 @@ SELECT id, path, representative_ext
 function metadata_normalize_keywords_string($keywords_string)
 {
   global $conf;
+  $sep = $conf['metadata_keyword_separator_char'];
   
-  $keywords_string = preg_replace($conf['metadata_keyword_separator_regex'], ',', $keywords_string);
   // new lines are always considered as keyword separators
-  $keywords_string = str_replace(array("\r\n", "\n", "\r"), ',', $keywords_string);
-  $keywords_string = preg_replace('/,+/', ',', $keywords_string);
-  $keywords_string = preg_replace('/^,+|,+$/', '', $keywords_string);
+  if ($conf['metadata_keyword_separator_regex'] != "") {
+      $keywords_string = preg_replace($conf['metadata_keyword_separator_regex'], $sep, $keywords_string);
+  }
+  $keywords_string = str_replace(array("\r\n", "\n", "\r"), $sep, $keywords_string);
+  $keywords_string = preg_replace('/'.preg_quote($sep).'+/', $sep, $keywords_string);
+  $keywords_string = preg_replace('/^'.preg_quote($sep).'+|'.preg_quote($sep).'+$/', '', $keywords_string);
       
   $keywords_string = implode(
-    ',',
+    $sep,
     array_unique(
       explode(
-        ',',
+        $sep,
         $keywords_string
         )
       )

--- a/admin/site_update.php
+++ b/admin/site_update.php
@@ -881,7 +881,7 @@ if (isset($_POST['submit']) and isset($_POST['sync_meta'])
             $tags_of[$id] = array();
           }
 
-          foreach (explode(',', $data[$key]) as $tag_name)
+          foreach (explode($conf['metadata_keyword_separator_char'], $data[$key]) as $tag_name)
           {
             $tags_of[$id][] = tag_id_from_tag_name($tag_name);
           }

--- a/include/config_default.inc.php
+++ b/include/config_default.inc.php
@@ -414,6 +414,9 @@ $conf['allow_html_in_metadata'] = false;
 // and IPTC). Coma "," cannot be removed from this list.
 $conf['metadata_keyword_separator_regex'] = '/[.,;]/';
 
+// character to split keyword list on
+$conf['metadata_keyword_separator_char'] = ',';
+
 // +-----------------------------------------------------------------------+
 // |                               sessions                                |
 // +-----------------------------------------------------------------------+

--- a/include/picture_metadata.inc.php
+++ b/include/picture_metadata.inc.php
@@ -66,7 +66,7 @@ if (($conf['show_exif']) and (function_exists('exif_read_data')))
 
 if ($conf['show_iptc'])
 {
-  $iptc = get_iptc_data($picture['current']['src_image']->get_path(), $conf['show_iptc_mapping'], ', ');
+  $iptc = get_iptc_data($picture['current']['src_image']->get_path(), $conf['show_iptc_mapping'], $conf['metadata_keyword_separator_char'].' ');
 
   if (count($iptc) > 0)
   {


### PR DESCRIPTION
Add configurable value for keyword split

Make the character on which keywords are temporarily joined into a string with a configuration value "metadata_keyword_separator_char". This character is always used to join all keywords into a string and then split them apart again later.
Default this to ',' to retain existing behaviour.

Change this to an unused character e.g. chr(127) in local/config/config.inc.php to permit use of ',' in keywords:

$conf['metadata_keyword_separator_char'] = chr(127);

It is then safe to remove your favourite separator characters from metadata_keyword_separator_regex, I find this config value works nicely if it is empty:

$conf['metadata_keyword_separator_regex'] = '';