### PR TITLE
Issue 2546 ws_categories_getList order with a limit

### DIFF
--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -326,7 +326,7 @@ SELECT SQL_CALC_FOUND_ROWS
   if (isset($params['limit']))
   {
     $query .= '
-  ORDER BY `rank` ASC 
+  ORDER BY `global_rank` ASC 
   LIMIT '.($params['limit'] + ($params['cat_id'] > 0 ? 1 : 0));
   }
 

--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -325,8 +325,12 @@ SELECT SQL_CALC_FOUND_ROWS
 
   if (isset($params['limit']))
   {
+    # The `cat_id` in question will always be first.
+    # Without this it will be inserted somewhere arbitrary into the rank of its child categories (based on its own rank within its uppercat, the grand-uppercat of the rest of the rows)
+    $uppercat_order = ($params['cat_id'] > 0) ? '(`id`='.(int)($params['cat_id']).') DESC, ':'';
+
     $query .= '
-  ORDER BY `global_rank` ASC 
+  ORDER BY '.$uppercat_order.'`rank` ASC 
   LIMIT '.($params['limit'] + ($params['cat_id'] > 0 ? 1 : 0));
   }
 


### PR DESCRIPTION
Fix Issue #2546.

One line (one token) change to get `ws_categories_getList` to return the proper results when `limit` is used.