### PR TITLE
Issue #2548 rotation missing from image lists

### DIFF
--- a/include/ws_functions/pwg.categories.php
+++ b/include/ws_functions/pwg.categories.php
@@ -120,7 +120,7 @@ SELECT SQL_CALC_FOUND_ROWS i.*
 
       $image = array();
       $image['is_favorite'] = isset($favorite_ids[ $row['id'] ]);
-      foreach (array('id', 'width', 'height', 'hit') as $k)
+      foreach (array('id', 'width', 'height', 'rotation', 'hit') as $k)
       {
         if (isset($row[$k]))
         {

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -555,7 +555,7 @@ SELECT id, date, author, content
   }
 
   $ret = $image_row;
-  foreach (array('id','width','height','hit','filesize') as $k)
+  foreach (array('id','width','height','hit','filesize', 'rotation') as $k)
   {
     if (isset($ret[$k]))
     {
@@ -705,7 +705,7 @@ SELECT *
     {
       $image = array();
       $image['is_favorite'] = isset($favorite_ids[ $row['id'] ]);
-      foreach (array('id', 'width', 'height', 'hit') as $k)
+      foreach (array('id', 'width', 'height', 'rotation', 'hit') as $k)
       {
         if (isset($row[$k]))
         {

--- a/include/ws_functions/pwg.images.php
+++ b/include/ws_functions/pwg.images.php
@@ -555,7 +555,7 @@ SELECT id, date, author, content
   }
 
   $ret = $image_row;
-  foreach (array('id','width','height','hit','filesize', 'rotation') as $k)
+  foreach (array('id','width','height','rotation','hit','filesize') as $k)
   {
     if (isset($ret[$k]))
     {

--- a/include/ws_functions/pwg.tags.php
+++ b/include/ws_functions/pwg.tags.php
@@ -149,7 +149,7 @@ SELECT *
       $image['rank'] = $rank_of[ $row['id'] ];
       $image['is_favorite'] = isset($favorite_ids[ $row['id'] ]);
 
-      foreach (array('id', 'width', 'height', 'hit') as $k)
+      foreach (array('id', 'width', 'height', 'rotation', 'hit') as $k)
       {
         if (isset($row[$k]))
         {

--- a/include/ws_functions/pwg.users.php
+++ b/include/ws_functions/pwg.users.php
@@ -800,7 +800,7 @@ SELECT
   {
     $image = array();
 
-    foreach (array('id', 'width', 'height', 'hit') as $k)
+    foreach (array('id', 'width', 'height', 'rotation', 'hit') as $k)
     {
       if (isset($row[$k]))
       {

--- a/themes/default/js/plugins/jquery.progressbar.js
+++ b/themes/default/js/plugins/jquery.progressbar.js
@@ -77,7 +77,8 @@ USAGE:
 						config.running_value	= 0;
 						config.image			= getBarImage(config);
 						
-						var numeric = ['steps', 'stepDuration', 'max', 'width', 'height', 'running_value', 'value'];
+						var numeric = ['steps', 'stepDuration', 'max', 'width', 'height', 
+							'rotation', 'running_value', 'value'];
 						for (var i=0; i<numeric.length; i++) 
 							config[numeric[i]] = parseInt(config[numeric[i]]);
 						


### PR DESCRIPTION
Issue #2548 - the `rotation` value isn't available in image lists, which means the `width` and `height` could be backwards but it isn't available or obvious if it is.

This update just adds rotation to a variety of image lists queries.