### PR TITLE
Fixes #2520 update functions.php to fix deprecated use of semicolon

### DIFF
--- a/admin/include/functions.php
+++ b/admin/include/functions.php
@@ -2782,7 +2782,7 @@ function get_active_menu($menu_page)
     case 'group_list':
     case 'group_perm':
     case 'notification_by_mail':
-    case 'user_activity';
+    case 'user_activity':
       return 2;
 
     case 'site_manager':


### PR DESCRIPTION
Case statements followed by a semicolon (;) are deprecated since >=php-8.5, use a colon (:) instead 
https://php-changed-behaviors.readthedocs.io/en/latest/behavior/case-with-semicolon.html