### PR TITLE
security: add allowed_classes => false to unserialize() in safe_unserialize(), picture.php, and template.class.php

### DIFF
--- a/i.php
+++ b/i.php
@@ -369,7 +369,7 @@ function safe_unserialize($value)
 {
   if (is_string($value))
   {
-    return unserialize($value);
+    return unserialize($value, ['allowed_classes' => false]);
   }
   return $value;
 }

--- a/include/template.class.php
+++ b/include/template.class.php
@@ -181,7 +181,7 @@ class Template
 
     if (!defined('IN_ADMIN') and isset($conf['extents_for_templates']))
     {
-      $tpl_extents = unserialize($conf['extents_for_templates']);
+      $tpl_extents = unserialize($conf['extents_for_templates'], ['allowed_classes' => false]);
       $this->set_extents($tpl_extents, './template-extension/', true, $theme);
     }
   }

--- a/picture.php
+++ b/picture.php
@@ -892,7 +892,7 @@ $infos['INFO_VISITS'] = $picture['current']['hit'];
 $infos['INFO_FILE'] = $picture['current']['file'];
 
 $template->assign($infos);
-$template->assign('display_info', unserialize($conf['picture_informations']));
+$template->assign('display_info', unserialize($conf['picture_informations'], ['allowed_classes' => false]));
 
 // related tags
 $tags = get_common_tags( array($page['image_id']), -1);


### PR DESCRIPTION
## Summary

Three `unserialize()` call sites process configuration values from Piwigo's database (`piwigo_config` table) without specifying `allowed_classes`.

### `safe_unserialize()` — `i.php`
Despite the name, this function only checks whether the input is a string before calling `unserialize()`. It doesn't restrict which PHP classes can be instantiated. This function is used throughout the codebase. An attacker who can write to the config table can inject a serialized object payload.

### `picture.php` — `picture_informations`
Deserializes the `picture_informations` configuration value, which is expected to be a plain array of display flags (booleans/integers).

### `template.class.php` — `extents_for_templates`
Deserializes the `extents_for_templates` configuration value, which is expected to be a plain array of template extension paths (strings).

## Fix
Added `['allowed_classes' => false]` to all three call sites. The stored values are plain PHP arrays — no objects are expected. Zero behavior change for valid data.