### PR TITLE
Skip video poster seek when ffprobe reports no numeric duration

### DIFF
--- a/admin/include/functions_upload.inc.php
+++ b/admin/include/functions_upload.inc.php
@@ -765,7 +765,7 @@ function upload_file_video($representative_ext, $file_path)
   // Get duration of video and determine time of poster
   exec('ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1'." '$file_path'", $O, $S);
 
-  if (!empty($O[0]))
+  if (!empty($O[0]) && is_numeric($O[0]))
   {
     $second = min(floor($O[0]*10)/10, 2);
   }


### PR DESCRIPTION
Fixes #2567.

When a video has no duration metadata (for example a webm captured from a stream), `ffprobe -show_entries format=duration` prints `N/A` instead of a number. The guard in `get_ffmpeg_video_thumb()` only checks `!empty($O[0])`, so `N/A` passes and `floor($O[0]*10)` evaluates `"N/A" * 10`, which is a fatal `Unsupported operand types` on PHP 8. The upload then silently fails with no gallery entry.

This adds an `is_numeric()` check so a non-numeric duration falls through to the existing `$second = 0` default, matching the reporter's own diagnosis in the issue.