### PR TITLE
Log representative downloads, the second part test repeated 'e'

### DIFF
--- a/action.php
+++ b/action.php
@@ -149,7 +149,7 @@ if ( empty($file) )
 if ($_GET['part'] == 'e') {
   pwg_log($_GET['id'], 'high');
 }
-else if ($_GET['part'] == 'e')
+else if ($_GET['part'] == 'r')
 {
   pwg_log($_GET['id'], 'other');
 }


### PR DESCRIPTION
`action.php` tests `$_GET['part'] == 'e'` twice in the same chain, so the second branch never runs and `pwg_log($_GET['id'], 'other')` is dead. The file itself says what the second one was meant to be: line 73 rejects anything outside `array('e','r','f')`, and the switch above handles all three, `e` for the original, `r` for the representative, `f` for the format. The logging chain covers `e` and `f` and repeats `e`, so a representative download is recorded nowhere at all right now.

Changed the second test to `'r'`, which is the only value left and the one whose `'other'` image type matches. I have not checked what this does to existing history statistics, and it will start adding rows that were previously missing.
